### PR TITLE
Misc tweaks, nothing that can be seen ingame.

### DIFF
--- a/Items/Magic/Airstrike/Airstrike.cs
+++ b/Items/Magic/Airstrike/Airstrike.cs
@@ -36,7 +36,7 @@ namespace EBF.Items.Magic.Airstrike
             Item.useTime = 40;//How fast the item is used
             Item.useAnimation = 40;//How long the animation lasts. For swords it should stay the same as UseTime
 
-            Item.value = Item.sellPrice(copper: 0, silver: 5, gold: 10, platinum: 0);//Item's value when sold
+            Item.value = Item.sellPrice(copper: 0, silver: 0, gold: 0, platinum: 0);//Item's value when sold
             Item.rare = ItemRarityID.Red;//Item's name colour, this is hardcoded by the modder and should be based on progression
             Item.autoReuse = true;//Boolean, if the item auto reuses if the use button is held
             Item.useTurn = true;//Boolean, if the player's direction can change while using the item

--- a/Items/Magic/DarkTooth.cs
+++ b/Items/Magic/DarkTooth.cs
@@ -34,14 +34,14 @@ namespace EBF.Items.Magic
             Item.useAnimation = 10;//How long the animation lasts. For swords it should stay the same as UseTime
             Item.channel = true;//Channeling the item when held
 
-            Item.shoot = ModContent.ProjectileType<DarkTooth_BlackHole>();
-            Item.shootSpeed = 0f;
-
             Item.value = Item.sellPrice(copper: 0, silver: 0, gold: 0, platinum: 0);//Item's value when sold
             Item.rare = ItemRarityID.Purple;//Item's name colour, this is hardcoded by the modder and should be based on 
             Item.autoReuse = false;//Boolean, if the item auto reuses if the use button is held
             Item.useTurn = true;//Boolean, if the player's direction can change while using the item
             Item.noMelee = true;
+
+            Item.shoot = ModContent.ProjectileType<DarkTooth_BlackHole>();
+            Item.shootSpeed = 0f;
         }
 
         public override void ModifyShootStats(Player player, ref Vector2 position, ref Vector2 velocity, ref int type, ref int damage, ref float knockback)

--- a/Items/Magic/DarkTooth.cs
+++ b/Items/Magic/DarkTooth.cs
@@ -37,7 +37,7 @@ namespace EBF.Items.Magic
             Item.shoot = ModContent.ProjectileType<DarkTooth_BlackHole>();
             Item.shootSpeed = 0f;
 
-            Item.value = Item.sellPrice(copper:0, silver:0, gold:50, platinum:1);//Item's value when sold
+            Item.value = Item.sellPrice(copper: 0, silver: 0, gold: 0, platinum: 0);//Item's value when sold
             Item.rare = ItemRarityID.Purple;//Item's name colour, this is hardcoded by the modder and should be based on 
             Item.autoReuse = false;//Boolean, if the item auto reuses if the use button is held
             Item.useTurn = true;//Boolean, if the player's direction can change while using the item

--- a/Items/Magic/DarkTooth.cs
+++ b/Items/Magic/DarkTooth.cs
@@ -52,14 +52,14 @@ namespace EBF.Items.Magic
         public override void HoldItem(Player player)
         {
             Color drawColor = Color.Black;
-            if (Main.rand.Next(2) == 0)
+            if (Main.rand.NextBool(2))
             {
                 drawColor = Color.Red;
             }
 
             if (player.channel)
             {
-                Dust.NewDustDirect(player.position, player.width, player.height, 302, 0f, 0f, 0, drawColor, 1f);
+                Dust.NewDustDirect(player.position, player.width, player.height, DustID.Terragrim, 0f, 0f, 0, drawColor, 1f);
             }
         }
         public override bool CanUseItem(Player player)
@@ -141,7 +141,7 @@ namespace EBF.Items.Magic
                     #region Dust Spawning
 
                     Color drawColor = Color.Black;
-                    if (Main.rand.Next(2) == 0)
+                    if (Main.rand.NextBool(2))
                     {
                         drawColor = Color.Red;
                     }
@@ -224,47 +224,26 @@ namespace EBF.Items.Magic
         //The growth rate of the black hole
         private void Scaling(Player player, Vector2 oldSize)
         {
-            /*if (player.HasBuff(ModContent.BuffType<HasteBuff>()))
+            float change = 0;
+
+            if (Projectile.width <= 150)
             {
-                if (Projectile.width <= 150)
-                {
-                    Projectile.scale += 0.2f;
-                }
-                else if (Projectile.width <= 325 && Projectile.width > 150)
-                {
-                    Projectile.scale += 0.1f;
-                }
-                else
-                {
-                    Projectile.scale += 0.05f;
-                }
-                Projectile.width = (int)(baseWidth * Projectile.scale);
-                Projectile.height = (int)(baseHeight * Projectile.scale);
-                Projectile.position = Projectile.position - (Projectile.Size - oldSize) / 2f;
-            }*/
-            //else
-            //{
-                if (Projectile.width <= 150)
-                {
-                    Projectile.scale += 0.1f;
-                }
-                else if (Projectile.width <= 325 && Projectile.width > 150)
-                {
-                    Projectile.scale += 0.05f;
-                }
-                else if (Projectile.width > 325 && Projectile.width <= 700)
-                {
-                    Projectile.scale += 0.025f;
-                }
-                else
-                {
-                    Projectile.scale += 0;
-                }
-                
-                Projectile.width = (int)(baseWidth * Projectile.scale);
-                Projectile.height = (int)(baseHeight * Projectile.scale);
-                Projectile.position = Projectile.position - (Projectile.Size - oldSize) / 2f;
-            //}
+                change = 0.1f;
+            }
+            else if (Projectile.width <= 325 && Projectile.width > 150)
+            {
+                change = 0.05f;
+            }
+            else if (Projectile.width > 325 && Projectile.width <= 700)
+            {
+                change = 0.025f;
+            }
+
+            Projectile.scale += change; //multiplied by haste if you want to
+
+            Projectile.width = (int)(baseWidth * Projectile.scale);
+            Projectile.height = (int)(baseHeight * Projectile.scale);
+            Projectile.position = Projectile.position - (Projectile.Size - oldSize) / 2f;
         }
         //NPC sucking
         private void Sucking(float SuckingRange)

--- a/Items/Magic/Flameheart/Flameheart.cs
+++ b/Items/Magic/Flameheart/Flameheart.cs
@@ -35,7 +35,7 @@ namespace EBF.Items.Magic.Flameheart
 
             Item.shoot = ModContent.ProjectileType<Flameheart_Fireball>();
 
-            Item.value = Item.sellPrice(copper: 0, silver: 0, gold: 3, platinum: 0);//Item's value when sold
+            Item.value = Item.sellPrice(copper: 0, silver: 0, gold: 0, platinum: 0);//Item's value when sold
             Item.rare = ItemRarityID.Red;//Item's name colour, this is hardcoded by the modder and should be based on progression
             Item.UseSound = SoundID.Item1;//The item's sound when it's used
             Item.autoReuse = false;//Boolean, if the item auto reuses if the use button is held

--- a/Items/Magic/Flameheart/Flameheart.cs
+++ b/Items/Magic/Flameheart/Flameheart.cs
@@ -33,13 +33,13 @@ namespace EBF.Items.Magic.Flameheart
             Item.useTime = 20;//How fast the item is used
             Item.useAnimation = 20;//How long the animation lasts. For swords it should stay the same as UseTime
 
-            Item.shoot = ModContent.ProjectileType<Flameheart_Fireball>();
-
             Item.value = Item.sellPrice(copper: 0, silver: 0, gold: 0, platinum: 0);//Item's value when sold
             Item.rare = ItemRarityID.Red;//Item's name colour, this is hardcoded by the modder and should be based on progression
             Item.UseSound = SoundID.Item1;//The item's sound when it's used
             Item.autoReuse = false;//Boolean, if the item auto reuses if the use button is held
             Item.useTurn = true;//Boolean, if the player's direction can change while using the item
+
+            Item.shoot = ModContent.ProjectileType<Flameheart_Fireball>();
         }
 
         public override void ModifyShootStats(Player player, ref Vector2 position, ref Vector2 velocity, ref int type, ref int damage, ref float knockback)

--- a/Items/Magic/Flameheart/Flameheart.cs
+++ b/Items/Magic/Flameheart/Flameheart.cs
@@ -1,12 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Terraria;
-using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -44,7 +38,7 @@ namespace EBF.Items.Magic.Flameheart
 
         public override void ModifyShootStats(Player player, ref Vector2 position, ref Vector2 velocity, ref int type, ref int damage, ref float knockback)
         {
-            if(++ChargeStacks >= 3)
+            if (++ChargeStacks >= 3)
             {
                 type = ModContent.ProjectileType<Flameheart_Firestorm>();
                 ChargeStacks = 0;
@@ -84,7 +78,7 @@ namespace EBF.Items.Magic.Flameheart
 
         public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
         {
-            if (Main.rand.NextFloat() < 0.9f)
+            if (Main.rand.NextBool(10))
             {
                 target.AddBuff(BuffID.OnFire, 300, false);
             }
@@ -98,24 +92,25 @@ namespace EBF.Items.Magic.Flameheart
 
             if (timer <= 0)
             {
-                int randomizer = Main.rand.Next(3);
+                //Randomize projectile
+                int chosenProjectile = 0;
+                switch (Main.rand.Next(3))
+                {
+                    case 0:
+                        chosenProjectile = ModContent.ProjectileType<Flameheart_FireballSmall>();
+                        break;
+                    case 1:
+                        chosenProjectile = ModContent.ProjectileType<Flameheart_FireballMed>();
+                        break;
+                    case 2:
+                        chosenProjectile = ModContent.ProjectileType<Flameheart_Fireball>();
+                        break;
+                }
 
+                //Spawn projectile
                 float X = Main.rand.NextFloat(-100f, 100f);
                 float Y = Main.rand.NextFloat(-100f, 100f);
-
-                if (randomizer == 0)
-                {
-                    int a = Projectile.NewProjectile(Projectile.GetSource_FromThis(), Projectile.Center.X + X, Projectile.Center.Y + Y, 0f, 0f, ModContent.ProjectileType<Flameheart_FireballSmall>(), 70, 0, Projectile.owner);
-                }
-                else if (randomizer == 2)
-                {
-                    int a = Projectile.NewProjectile(Projectile.GetSource_FromThis(), Projectile.Center.X + X, Projectile.Center.Y + Y, 0f, 0f, ModContent.ProjectileType<Flameheart_FireballMed>(), 70, 0, Projectile.owner);
-                }
-                else
-                {
-                    int a = Projectile.NewProjectile(Projectile.GetSource_FromThis(), Projectile.Center.X + X, Projectile.Center.Y + Y, 0f, 0f, ModContent.ProjectileType<Flameheart_Fireball>(), 70, 0, Projectile.owner);
-                }
-
+                Projectile.NewProjectile(Projectile.GetSource_FromThis(), Projectile.Center.X + X, Projectile.Center.Y + Y, 0f, 0f, chosenProjectile, 70, 0, Projectile.owner);
                 timer = 5;
             }
         }
@@ -151,12 +146,11 @@ namespace EBF.Items.Magic.Flameheart
 
             Projectile.localNPCHitCooldown = -1;
             Projectile.usesLocalNPCImmunity = true;
-
         }
 
         public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
         {
-            if (Main.rand.NextFloat() < 0.4f)
+            if (Main.rand.NextBool(3))
             {
                 target.AddBuff(BuffID.OnFire, 300, false);
             }
@@ -164,12 +158,11 @@ namespace EBF.Items.Magic.Flameheart
 
         public override void AI()
         {
-            if (Main.rand.Next(3) == 0)
+            if (Main.rand.NextBool(3))
             {
-                Dust dust;
                 // You need to set position depending on what you are doing. You may need to subtract width/2 and height/2 as well to center the spawn rectangle.
                 Vector2 position = Projectile.position;
-                dust = Dust.NewDustDirect(position, Projectile.width, Projectile.height, DustID.Torch, 0.2631578f, -2.368421f, 0, new Color(255, 251, 0), 1.25f);
+                Dust.NewDustDirect(position, Projectile.width, Projectile.height, DustID.Torch, 0.2631578f, -2.368421f, 0, new Color(255, 251, 0), 1.25f);
             }
 
             if (++Projectile.frameCounter > 3)
@@ -215,7 +208,7 @@ namespace EBF.Items.Magic.Flameheart
 
         public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
         {
-            if (Main.rand.NextFloat() < 0.4f)
+            if (Main.rand.NextBool(3))
             {
                 target.AddBuff(BuffID.OnFire, 300, false);
             }
@@ -223,12 +216,11 @@ namespace EBF.Items.Magic.Flameheart
 
         public override void AI()
         {
-            if (Main.rand.Next(3) == 0)
+            if (Main.rand.NextBool(3))
             {
-                Dust dust;
                 // You need to set position depending on what you are doing. You may need to subtract width/2 and height/2 as well to center the spawn rectangle.
                 Vector2 position = Projectile.position;
-                dust = Dust.NewDustDirect(position, Projectile.width, Projectile.height, DustID.Pixie, 0.2631578f, -2.368421f, 0, new Color(255, 251, 0), 1.25f);
+                Dust.NewDustDirect(position, Projectile.width, Projectile.height, DustID.Pixie, 0.2631578f, -2.368421f, 0, new Color(255, 251, 0), 1.25f);
             }
 
             if (++Projectile.frameCounter > 3)
@@ -275,12 +267,11 @@ namespace EBF.Items.Magic.Flameheart
 
             Projectile.localNPCHitCooldown = -1;
             Projectile.usesLocalNPCImmunity = true;
-
         }
 
         public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
         {
-            if (Main.rand.NextFloat() < 0.4f)
+            if (Main.rand.NextBool(3))
             {
                 target.AddBuff(BuffID.OnFire, 300, false);
             }
@@ -288,12 +279,11 @@ namespace EBF.Items.Magic.Flameheart
 
         public override void AI()
         {
-            if (Main.rand.Next(3) == 0)
+            if (Main.rand.NextBool(3))
             {
-                Dust dust;
                 // You need to set position depending on what you are doing. You may need to subtract width/2 and height/2 as well to center the spawn rectangle.
                 Vector2 position = Projectile.position;
-                dust = Dust.NewDustDirect(position, Projectile.width, Projectile.height, DustID.Pixie, 0.2631578f, -2.368421f, 0, new Color(255, 251, 0), 1.25f);
+                Dust.NewDustDirect(position, Projectile.width, Projectile.height, DustID.Pixie, 0.2631578f, -2.368421f, 0, new Color(255, 251, 0), 1.25f);
             }
 
             if (++Projectile.frameCounter > 3)
@@ -310,6 +300,7 @@ namespace EBF.Items.Magic.Flameheart
         {
             return true;
         }
+
         /*public override bool PreDraw(ref Color lightColor)
         {
             Main.spriteBatch.End();

--- a/Items/Magic/Seraphim.cs
+++ b/Items/Magic/Seraphim.cs
@@ -39,7 +39,7 @@ namespace EBF.Items.Magic
 			Item.shoot = ModContent.ProjectileType<Seraphim_Judgement>();
 			Item.shootSpeed = 0f;
 
-			Item.value = Item.sellPrice(copper:0, silver:0, gold:50, platinum:1);//Item's value when sold
+			Item.value = Item.sellPrice(copper:0, silver:0, gold: 0, platinum: 0);//Item's value when sold
 			Item.rare = ItemRarityID.Purple;//Item's name colour, this is hardcoded by the modder and should be based on progression
 			Item.UseSound = SoundID.Item1;//The item's sound when it's used
 			Item.autoReuse = false;//Boolean, if the item auto reuses if the use button is held

--- a/Items/Magic/Seraphim.cs
+++ b/Items/Magic/Seraphim.cs
@@ -36,14 +36,14 @@ namespace EBF.Items.Magic
 			Item.useTime = 10;//How fast the item is used
 			Item.useAnimation = 10;//How long the animation lasts. For swords it should stay the same as UseTime
 
-			Item.shoot = ModContent.ProjectileType<Seraphim_Judgement>();
-			Item.shootSpeed = 0f;
-
 			Item.value = Item.sellPrice(copper:0, silver:0, gold: 0, platinum: 0);//Item's value when sold
 			Item.rare = ItemRarityID.Purple;//Item's name colour, this is hardcoded by the modder and should be based on progression
 			Item.UseSound = SoundID.Item1;//The item's sound when it's used
 			Item.autoReuse = false;//Boolean, if the item auto reuses if the use button is held
 			Item.useTurn = true;//Boolean, if the player's direction can change while using the item
+
+			Item.shoot = ModContent.ProjectileType<Seraphim_Judgement>();
+			Item.shootSpeed = 0f;
 		}
 
 		public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)

--- a/Items/Magic/ShootingStar.cs
+++ b/Items/Magic/ShootingStar.cs
@@ -34,7 +34,7 @@ namespace EBF.Items.Magic
             Item.useTime = 20;//How fast the item is used
             Item.useAnimation = 20;//How long the animation lasts. For swords it should stay the same as UseTime
 
-            Item.value = Item.sellPrice(copper:10, silver:10, gold:10, platinum:1);//Item's value when sold
+            Item.value = Item.sellPrice(copper: 0, silver: 0, gold: 0, platinum: 0);//Item's value when sold
             Item.rare = ItemRarityID.Green;//Item's name colour, this is hardcoded by the modder and should be based on progression
             Item.UseSound = SoundID.Item1;//The item's sound when it's used
             Item.autoReuse = true;//Boolean, if the item auto reuses if the use button is held

--- a/Items/Magic/ShootingStar.cs
+++ b/Items/Magic/ShootingStar.cs
@@ -153,8 +153,8 @@ namespace EBF.Items.Magic
             if (Shrkinking)
             {
                 Projectile.scale -= 0.01f;
-                
-                if(Projectile.scale <= 0)
+
+                if (Projectile.scale <= 0)
                 {
                     Projectile.Kill();
                 }

--- a/Items/Magic/SpellProtect.cs
+++ b/Items/Magic/SpellProtect.cs
@@ -35,7 +35,7 @@ namespace EBF.Items.Magic
             Item.useAnimation = 10;
             Item.mana = 5;
             Item.rare = ItemRarityID.Yellow;
-            Item.value = Item.sellPrice(silver: 50);
+            Item.value = Item.sellPrice(copper: 0, silver: 0, gold: 0, platinum: 0);
             Item.useTurn = true;
             /*if (!Main.dedServ)
             {

--- a/Items/Magic/SpellRegeneration.cs
+++ b/Items/Magic/SpellRegeneration.cs
@@ -28,9 +28,8 @@ namespace EBF.Items.Magic
             Item.useAnimation = 10;
             Item.mana = 100;
             Item.rare = ItemRarityID.Yellow;
-            Item.value = Item.sellPrice(silver: 50);
+            Item.value = Item.sellPrice(copper: 0, silver: 0, gold: 0, platinum: 0);
             Item.useTurn = true;
-            Item.value = Item.sellPrice(gold: 10);
         }
 
         public override bool CanUseItem(Player player)

--- a/Items/Melee/Avenger.cs
+++ b/Items/Melee/Avenger.cs
@@ -30,7 +30,7 @@ namespace EBF.Items.Melee
             Item.useTime = 30;//How fast the item is used
             Item.useAnimation = 30;//How long the animation lasts. For swords it should stay the same as UseTime
 
-            Item.value = Item.sellPrice(copper:0, silver:50, gold:1, platinum:0);//Item's value when sold
+            Item.value = Item.sellPrice(copper: 0, silver: 0, gold: 0, platinum: 0);//Item's value when sold
             Item.rare = ItemRarityID.Cyan;//Item's name colour, this is hardcoded by the modder and should be based on progression
             Item.UseSound = SoundID.Item1;//The item's sound when it's used
             Item.autoReuse = true;//Boolean, if the item auto reuses if the use button is held

--- a/Items/Melee/Avenger.cs
+++ b/Items/Melee/Avenger.cs
@@ -9,7 +9,7 @@ using Terraria.ID;
 
 namespace EBF.Items.Melee
 {
-    public class Avenger: ModItem
+    public class Avenger : ModItem
     {
         int missHP;//The missing health of the player
         public override void SetStaticDefaults()

--- a/Items/Melee/Berzerker.cs
+++ b/Items/Melee/Berzerker.cs
@@ -28,8 +28,8 @@ namespace EBF.Items.Melee
             Item.useStyle = ItemUseStyleID.Swing;//The animation of the item when used
             Item.useTime = 25;//How fast the item is used
             Item.useAnimation = 25;//How long the animation lasts. For swords it should stay the same as UseTime
-            
-            Item.value = Item.sellPrice(copper: 0, silver: 50, gold: 0, platinum: 0);//Item's value when sold
+
+            Item.value = Item.sellPrice(copper: 0, silver: 0, gold: 0, platinum: 0);//Item's value when sold
             Item.rare = ItemRarityID.Cyan;//Item's name colour, this is hardcoded by the modder and should be based on progression
             Item.UseSound = SoundID.Item1;//The item's sound when it's used
             Item.autoReuse = true;//Boolean, if the item auto reuses if the use button is held

--- a/Items/Melee/BlackFang.cs
+++ b/Items/Melee/BlackFang.cs
@@ -29,7 +29,7 @@ namespace EBF.Items.Melee
 			Item.useTime = 25;//How fast the item is used
 			Item.useAnimation = 25;//How long the animation lasts. For swords it should stay the same as UseTime
 
-			Item.value = Item.sellPrice(copper:0, silver:50, gold:1, platinum:0);//Item's value when sold
+			Item.value = Item.sellPrice(copper: 0, silver: 0, gold: 0, platinum: 0);//Item's value when sold
 			Item.rare = ItemRarityID.Cyan;//Item's name colour, this is hardcoded by the modder and should be based on progression
 			Item.UseSound = SoundID.Item1;//The item's sound when it's used
 			Item.autoReuse = true;//Boolean, if the item auto reuses if the use button is held

--- a/Items/Melee/Blizzard.cs
+++ b/Items/Melee/Blizzard.cs
@@ -59,6 +59,6 @@ namespace EBF.Items.Melee
         }
 
         //It would be nice to move this method out of blizzard, but there's not enough vector logic to warrant an extension class.
-        private Vector2 GetRandomVector() => new Vector2(Main.rand.NextFloat() * 2 - 1, Main.rand.NextFloat() * 2 - 1);
+        private Vector2 GetRandomVector() => new Vector2(Main.rand.NextFloat(-1, 1), Main.rand.NextFloat(-1, 1));
     }
 }

--- a/Items/Melee/FusionBlade.cs
+++ b/Items/Melee/FusionBlade.cs
@@ -31,7 +31,7 @@ namespace EBF.Items.Melee
 			Item.useTime = 20;//How fast the item is used
 			Item.useAnimation = 20;//How long the animation lasts. For swords it should stay the same as UseTime
 
-			Item.value = Item.sellPrice(copper:10, silver:20, gold:30, platinum:0);//Item's value when sold
+			Item.value = Item.sellPrice(copper: 0, silver: 0, gold: 0, platinum: 0);//Item's value when sold
 			Item.rare = ItemRarityID.Orange;//Item's name colour, this is hardcoded by the modder and should be based on progression
 			Item.UseSound = SoundID.Item1;//The item's sound when it's used
 			Item.autoReuse = true;//Boolean, if the item auto reuses if the use button is held

--- a/Items/Melee/FusionBlade.cs
+++ b/Items/Melee/FusionBlade.cs
@@ -36,6 +36,7 @@ namespace EBF.Items.Melee
 			Item.UseSound = SoundID.Item1;//The item's sound when it's used
 			Item.autoReuse = true;//Boolean, if the item auto reuses if the use button is held
 			Item.useTurn = false;//Boolean, if the player's direction can change while using the item
+
 			Item.shoot = ModContent.ProjectileType<FusionBlade_BulletBob>();
 			Item.shootSpeed = 1f;
 		}

--- a/Items/Melee/HeavensGate.cs
+++ b/Items/Melee/HeavensGate.cs
@@ -35,7 +35,7 @@ namespace EBF.Items.Melee
             Item.useTime = 30;//How fast the item is used
             Item.useAnimation = 30;//How long the animation lasts. For swords it should stay the same as UseTime
 
-            Item.value = Item.sellPrice(copper:0, silver:50, gold:1, platinum:0);//Item's value when sold
+            Item.value = Item.sellPrice(copper: 0, silver: 0, gold: 0, platinum: 0);//Item's value when sold
             Item.rare = ItemRarityID.Red;//Item's name colour, this is hardcoded by the modder and should be based on progression
             Item.UseSound = SoundID.Item1;//The item's sound when it's used
             Item.autoReuse = true;//Boolean, if the item auto reuses if the use button is held

--- a/Items/Melee/HeavensGate.cs
+++ b/Items/Melee/HeavensGate.cs
@@ -45,7 +45,7 @@ namespace EBF.Items.Melee
         }
         public override void MeleeEffects(Player player, Rectangle hitbox)
         {
-            if(Main.rand.NextFloat() <= 0.3f)
+            if (Main.rand.NextFloat() <= 0.3f)
             {
                 int dust = Dust.NewDust(new Vector2(hitbox.X, hitbox.Y), hitbox.Width, hitbox.Height, DustID.AncientLight);
                 Main.dust[dust].noGravity = true;
@@ -56,7 +56,7 @@ namespace EBF.Items.Melee
         {
             Vector2 VelocityManual = new Vector2(velocity.X, velocity.Y);//We store the velocity for later use
 
-            Projectile.NewProjectile(source, Main.MouseWorld - (Vector2.Normalize(VelocityManual) * 80f), Vector2.Zero, type, damage, knockback, player.whoAmI, velocity.X , velocity.Y);//We use VelocityManual to push the created sword towards the player in reference of the mouse
+            Projectile.NewProjectile(source, Main.MouseWorld - (Vector2.Normalize(VelocityManual) * 80f), Vector2.Zero, type, damage, knockback, player.whoAmI, velocity.X, velocity.Y);//We use VelocityManual to push the created sword towards the player in reference of the mouse
 
             return false;
         }

--- a/Items/Melee/HeavensGate.cs
+++ b/Items/Melee/HeavensGate.cs
@@ -1,17 +1,8 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.DataStructures;
-using Terraria.GameContent;
 using Terraria.ID;
 using Terraria.ModLoader;
-using EBF.Extensions;
 
 namespace EBF.Items.Melee
 {
@@ -127,14 +118,7 @@ namespace EBF.Items.Melee
 
         public override bool? CanDamage() //If it's not fully form, do not damage
         {
-            if (Projectile.frame == 4)
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            return Projectile.frame == 4;
         }
         public override bool PreAI()//Use this to write the AI of the projectile. Its behaviour in other words. Updates every frame.
         {
@@ -325,7 +309,6 @@ namespace EBF.Items.Melee
             Father = Main.projectile[(int)Projectile.ai[1]];
             if (!DistanceSet)//Setting the distance of the Projectile from the cursor
             {
-
                 SpawnPosition = target.Center - Vector2.Normalize(Projectile.velocity) * 80f;
 
                 SpawnDistanceFromTarget = Vector2.Distance(SpawnPosition, target.Center);
@@ -334,8 +317,8 @@ namespace EBF.Items.Melee
                 MoveSpeed = Projectile.velocity;
             }
 
-            //Change the 5 to determine how much dust will spawn. lower for more, higher for less
-            if (Main.rand.Next(3) == 0)
+            //Change the number to determine how much dust will spawn. lower for more, higher for less
+            if (Main.rand.NextBool(3))
             {
                 int dust = Dust.NewDust(Projectile.position, Projectile.width, Projectile.height, DustID.AncientLight);
                 Main.dust[dust].velocity.X *= 0.4f;

--- a/Items/Melee/HeavensGate.cs
+++ b/Items/Melee/HeavensGate.cs
@@ -40,6 +40,7 @@ namespace EBF.Items.Melee
             Item.UseSound = SoundID.Item1;//The item's sound when it's used
             Item.autoReuse = true;//Boolean, if the item auto reuses if the use button is held
             Item.useTurn = false;//Boolean, if the player's direction can change while using the item
+
             Item.shoot = ModContent.ProjectileType<HeavensGate_LightBlade>();
             Item.shootSpeed = 5f;
         }

--- a/Items/Melee/HeavensGate.cs
+++ b/Items/Melee/HeavensGate.cs
@@ -56,12 +56,12 @@ namespace EBF.Items.Melee
 
     public class HeavensGate_LightBlade : ModProjectile
     {
-        float SpawnDistanceFromClick;
-        bool DistanceSet = false;
-        bool Stop = false;
-        Vector2 SpawnPosition;
-        Vector2 OldMouseWorld;
-        int TrailSkip = 2;
+        private float SpawnDistanceFromClick;
+        private bool DistanceSet = false;
+        private bool Stop = false;
+        private Vector2 SpawnPosition;
+        private Vector2 OldMouseWorld;
+        private int TrailSkip = 2;
 
 
         public override void SetStaticDefaults()//Mainly used for setting the frames of animations or things we don't want to change in the projectile
@@ -225,14 +225,14 @@ namespace EBF.Items.Melee
 
     public class HeavensGate_LightBlade_Mini : ModProjectile
     {
-        float SpawnDistanceFromTarget;
-        bool DistanceSet = false;
-        bool Stop = false;
-        Vector2 SpawnPosition;
-        Vector2 OldTargetPosition;
-        Vector2 MoveSpeed;
+        private float SpawnDistanceFromTarget;
+        private bool DistanceSet = false;
+        private bool Stop = false;
+        private Vector2 SpawnPosition;
+        private Vector2 OldTargetPosition;
+        private Vector2 MoveSpeed;
 
-        Projectile Father;
+        private Projectile Father;
         public override void SetStaticDefaults()
         {
             Main.projFrames[Projectile.type] = 11;

--- a/Items/Melee/Inferno.cs
+++ b/Items/Melee/Inferno.cs
@@ -84,8 +84,8 @@ namespace EBF.Items.Melee
         {
 			target.AddBuff(BuffID.OnFire, 60 * 2);
 
-			if(hit.Damage >= target.life)
-			{
+            if (hit.Damage >= target.life)
+            {
                 for (int i = 0; i < 4; i++)
                 {
                     float randomRotation = Main.rand.NextFloat(0, 360);

--- a/Items/Melee/Inferno.cs
+++ b/Items/Melee/Inferno.cs
@@ -33,7 +33,7 @@ namespace EBF.Items.Melee
 			Item.useTime = 20;//How fast the item is used
 			Item.useAnimation = 20;//How long the animation lasts. For swords it should stay the same as UseTime
 
-			Item.value = Item.sellPrice(copper:0, silver:50, gold:1, platinum:0);//Item's value when sold
+			Item.value = Item.sellPrice(copper: 0, silver: 0, gold: 0, platinum: 0);//Item's value when sold
 			Item.rare = ItemRarityID.Cyan;//Item's name colour, this is hardcoded by the modder and should be based on progression
 			Item.UseSound = SoundID.Item1;//The item's sound when it's used
 			Item.autoReuse = true;//Boolean, if the item auto reuses if the use button is held

--- a/Items/Melee/LoveBlade.cs
+++ b/Items/Melee/LoveBlade.cs
@@ -28,8 +28,8 @@ namespace EBF.Items.Melee
             Item.useStyle = ItemUseStyleID.Swing;//The animation of the item when used
             Item.useTime = 25;//How fast the item is used
             Item.useAnimation = 25;//How long the animation lasts. For swords it should stay the same as UseTime
-            
-            Item.value = Item.sellPrice(copper: 0, silver: 50, gold: 0, platinum: 0);//Item's value when sold
+
+            Item.value = Item.sellPrice(copper: 0, silver: 0, gold: 0, platinum: 0);//Item's value when sold
             Item.rare = ItemRarityID.Cyan;//Item's name colour, this is hardcoded by the modder and should be based on progression
             Item.UseSound = SoundID.Item1;//The item's sound when it's used
             Item.autoReuse = true;//Boolean, if the item auto reuses if the use button is held

--- a/Items/Melee/Spears/GiantSlayer.cs
+++ b/Items/Melee/Spears/GiantSlayer.cs
@@ -30,7 +30,7 @@ namespace EBF.Items.Melee.Spears
             Item.height = 32;
             Item.scale = 0.7f;
             Item.rare = ItemRarityID.Pink;
-            Item.value = Item.sellPrice(gold: 10);
+            Item.value = Item.sellPrice(copper: 0, silver: 0, gold: 0, platinum: 0);//Item's value when sold
             Item.DamageType = DamageClass.Melee; ;
             Item.noMelee = true; // Important because the spear is actually a projectile instead of an Item. This prevents the melee hitbox of this Item.
             Item.noUseGraphic = true; // Important, it's kind of wired if people see two spears at one time. This prevents the melee animation of this Item.

--- a/Items/Melee/SwordBreaker.cs
+++ b/Items/Melee/SwordBreaker.cs
@@ -28,8 +28,8 @@ namespace EBF.Items.Melee
             Item.useStyle = ItemUseStyleID.Swing;//The animation of the item when used
             Item.useTime = 25;//How fast the item is used
             Item.useAnimation = 25;//How long the animation lasts. For swords it should stay the same as UseTime
-            
-            Item.value = Item.sellPrice(copper: 0, silver: 50, gold: 0, platinum: 0);//Item's value when sold
+
+            Item.value = Item.sellPrice(copper: 0, silver: 0, gold: 0, platinum: 0);//Item's value when sold
             Item.rare = ItemRarityID.Cyan;//Item's name colour, this is hardcoded by the modder and should be based on progression
             Item.UseSound = SoundID.Item1;//The item's sound when it's used
             Item.autoReuse = true;//Boolean, if the item auto reuses if the use button is held

--- a/Items/Melee/Throwable/IceNeedle.cs
+++ b/Items/Melee/Throwable/IceNeedle.cs
@@ -20,7 +20,8 @@ namespace EBF.Items.Melee.Throwable
 
         public override void SetDefaults()
         {
-            Item.width = Item.height = 72;
+            Item.width = 72;
+            Item.height = 72;
 
             Item.damage = 40;
             Item.knockBack = 1f;
@@ -32,11 +33,10 @@ namespace EBF.Items.Melee.Throwable
 
             Item.rare = ItemRarityID.LightPurple;
             Item.value = Item.sellPrice(copper: 0, silver: 0, gold: 0, platinum: 0);//Item's value when sold
+            Item.useTurn = false;
 
             Item.shoot = ModContent.ProjectileType<IceNeedle_Proj>();
             Item.shootSpeed = 16f;
-
-            Item.useTurn = false;
 
             Item.noUseGraphic = true;
         }

--- a/Items/Melee/Throwable/IceNeedle.cs
+++ b/Items/Melee/Throwable/IceNeedle.cs
@@ -31,6 +31,7 @@ namespace EBF.Items.Melee.Throwable
             Item.useStyle = ItemUseStyleID.Swing;
 
             Item.rare = ItemRarityID.LightPurple;
+            Item.value = Item.sellPrice(copper: 0, silver: 0, gold: 0, platinum: 0);//Item's value when sold
 
             Item.shoot = ModContent.ProjectileType<IceNeedle_Proj>();
             Item.shootSpeed = 16f;

--- a/Items/Melee/Throwable/IceNeedle.cs
+++ b/Items/Melee/Throwable/IceNeedle.cs
@@ -121,9 +121,9 @@ namespace EBF.Items.Melee.Throwable
             get => (Behaviour)behave;
             set => behave = (float)value;
         }
-        float behave = 0f;
-
-        bool FrameFound;
+        private List<NPC> validNPCs;
+        private float behave = 0f;
+        private bool FrameFound;
         public override void SetStaticDefaults()
         {
             Main.projFrames[Projectile.type] = 3;
@@ -149,6 +149,9 @@ namespace EBF.Items.Melee.Throwable
             {
                 FrameFound = true;
                 Projectile.frame = Main.rand.Next(0, 2);
+
+                //Get all valid npcs to target using the following criteria (reduces search size for homing)
+                validNPCs = Main.npc.ToList<NPC>().FindAll(x => x.active && !x.dontTakeDamage && !x.friendly && x.lifeMax > 5);
             }
             if (Behave == Behaviour.Idle)//If the Projectile is idle then slow down smoothly
             {
@@ -176,18 +179,15 @@ namespace EBF.Items.Melee.Throwable
             Vector2 move = Vector2.Zero;
             float distance = 125f;
             bool target = false;
-            for (int k = 0; k < 200; k++)
+            foreach(NPC npc in validNPCs)
             {
-                if (Main.npc[k].active && !Main.npc[k].dontTakeDamage && !Main.npc[k].friendly && Main.npc[k].lifeMax > 5)
+                Vector2 newMove = npc.Center - Projectile.Center;
+                float distanceTo = (float)Math.Sqrt(newMove.X * newMove.X + newMove.Y * newMove.Y);
+                if (distanceTo < distance)
                 {
-                    Vector2 newMove = Main.npc[k].Center - Projectile.Center;
-                    float distanceTo = (float)Math.Sqrt(newMove.X * newMove.X + newMove.Y * newMove.Y);
-                    if (distanceTo < distance)
-                    {
-                        move = newMove;
-                        distance = distanceTo;
-                        target = true;
-                    }
+                    move = newMove;
+                    distance = distanceTo;
+                    target = true;
                 }
             }
             if (target)

--- a/Items/Melee/UltraPro9000X.cs
+++ b/Items/Melee/UltraPro9000X.cs
@@ -23,7 +23,7 @@ namespace EBF.Items.Melee
             Item.height = 100;//Height of the hitbox of the item (usually the item's sprite height)
 
             Item.damage = 13;//Item's base damage value
-            Item.knockBack =16f ;//Float, the item's knockback value. How far the enemy is launched when hit
+            Item.knockBack = 16f;//Float, the item's knockback value. How far the enemy is launched when hit
             Item.DamageType = DamageClass.Melee;//Item's damage type, Melee, Ranged, Magic and Summon. Custom damage are also a thing
             Item.useStyle = ItemUseStyleID.Swing;//The animation of the item when used
             Item.useTime = 30;//How fast the item is used

--- a/Items/Melee/UltraPro9000X.cs
+++ b/Items/Melee/UltraPro9000X.cs
@@ -29,7 +29,7 @@ namespace EBF.Items.Melee
             Item.useTime = 30;//How fast the item is used
             Item.useAnimation = 30;//How long the animation lasts. For swords it should stay the same as UseTime
 
-            Item.value = Item.sellPrice(copper:0, silver:50, gold:1, platinum:0);//Item's value when sold
+            Item.value = Item.sellPrice(copper: 0, silver: 0, gold: 0, platinum: 0);//Item's value when sold
             Item.rare = ItemRarityID.Green;//Item's name colour, this is hardcoded by the modder and should be based on progression
             Item.UseSound = SoundID.Item1;//The item's sound when it's used
             Item.autoReuse = true;//Boolean, if the item auto reuses if the use button is held


### PR DESCRIPTION
- Removed sell price on all weapons that do not yet have a recipe.
- Optimized ice needle by giving it a list of npcs that are targetable, and only iterating through it instead of every npc in the world per frame.
- Consistent indentation in various weapons.
- Explicitly written accessors for private fields in heaven's gate. Also simplified the CanDamage method to one line.
- Rearranged line order of default stats in some weapons, so they match other weapons.
- Code readability improvements for Flameheart and DarkTooth