### PR TITLE
Updated Localization

### DIFF
--- a/Items/Accessories/Flairs/AngryFaic.cs
+++ b/Items/Accessories/Flairs/AngryFaic.cs
@@ -1,21 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace EBF.Items.Accessories.Flairs
 {
-    public class AngryFaic : ModItem
+    public class AngryFaic : ModItem, ILocalizedModType
     {
-        public override void SetStaticDefaults()
-        {
-            base.DisplayName.WithFormatArgs("Angry Faic");
-            base.Tooltip.WithFormatArgs("Wearing this makes you so angry, you want something to be BLAMMED!\n2 defense\nIncreases critical chance by 8%.\nIncreases enemy aggression.");
-        }
+        public new string LocalizationCategory => "Items.Accessories";
+            //base.Tooltip.WithFormatArgs("Wearing this makes you so angry, you want something to be BLAMMED!\n2 defense\nIncreases critical chance by 8%.\nIncreases enemy aggression.");
+        
         public override void SetDefaults()
         {
             Item.width = 32;

--- a/Items/Accessories/Flairs/AngryFaic.cs
+++ b/Items/Accessories/Flairs/AngryFaic.cs
@@ -1,5 +1,4 @@
-﻿
-using Terraria;
+﻿using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -8,8 +7,6 @@ namespace EBF.Items.Accessories.Flairs
     public class AngryFaic : ModItem, ILocalizedModType
     {
         public new string LocalizationCategory => "Items.Accessories";
-            //base.Tooltip.WithFormatArgs("Wearing this makes you so angry, you want something to be BLAMMED!\n2 defense\nIncreases critical chance by 8%.\nIncreases enemy aggression.");
-        
         public override void SetDefaults()
         {
             Item.width = 32;

--- a/Items/Accessories/Flairs/BalanceBadge.cs
+++ b/Items/Accessories/Flairs/BalanceBadge.cs
@@ -1,22 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Terraria.ID;
+﻿using Terraria.ID;
 using Terraria.ModLoader;
-using Terraria.Utilities;
 using Terraria;
 
 namespace EBF.Items.Accessories.Flairs
 {
-    public class BalanceBadge  : ModItem
+    public class BalanceBadge  : ModItem, ILocalizedModType
     {
-        public override void SetStaticDefaults()
-        {
-            base.DisplayName.WithFormatArgs("Balance Badge");
-            base.Tooltip.WithFormatArgs("Represents pure equilibrium and bestows a wealth of boosts.\n5 defense\nIncreases maximum health and mana by 10\nIncreases movement, attack speed, damage and crit chance by 5%\nIncreases max minion slots by 1");
-        }
+        public new string LocalizationCategory => "Items.Accessories";
+            //base.Tooltip.WithFormatArgs("Represents pure equilibrium and bestows a wealth of boosts.\n5 defense\nIncreases maximum health and mana by 10\nIncreases movement, attack speed, damage and crit chance by 5%\nIncreases max minion slots by 1");
+        
         public override void SetDefaults()
         {
             Item.width = 20;

--- a/Items/Accessories/Flairs/BalanceBadge.cs
+++ b/Items/Accessories/Flairs/BalanceBadge.cs
@@ -7,8 +7,6 @@ namespace EBF.Items.Accessories.Flairs
     public class BalanceBadge  : ModItem, ILocalizedModType
     {
         public new string LocalizationCategory => "Items.Accessories";
-            //base.Tooltip.WithFormatArgs("Represents pure equilibrium and bestows a wealth of boosts.\n5 defense\nIncreases maximum health and mana by 10\nIncreases movement, attack speed, damage and crit chance by 5%\nIncreases max minion slots by 1");
-        
         public override void SetDefaults()
         {
             Item.width = 20;

--- a/Items/Accessories/Flairs/GreenCross.cs
+++ b/Items/Accessories/Flairs/GreenCross.cs
@@ -7,7 +7,6 @@ namespace EBF.Items.Accessories.Flairs
     public class GreenCross : ModItem, ILocalizedModType
     {
         public new string LocalizationCategory => "Items.Accessories";
-           // base.Tooltip.WithFormatArgs("A Geneva-Convention-friendly pin which boasts regenerative properties.\nRegenerates 5% of your maximum health every 10 seconds");//Tooltip of the item
 
         private int timer = 60 * 10;//10 second timer
         private const int healthPercentage = 5;

--- a/Items/Accessories/Flairs/GreenCross.cs
+++ b/Items/Accessories/Flairs/GreenCross.cs
@@ -1,25 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Terraria;
+﻿using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace EBF.Items.Accessories.Flairs
 {
-    public class GreenCross : ModItem
+    public class GreenCross : ModItem, ILocalizedModType
     {
+        public new string LocalizationCategory => "Items.Accessories";
+           // base.Tooltip.WithFormatArgs("A Geneva-Convention-friendly pin which boasts regenerative properties.\nRegenerates 5% of your maximum health every 10 seconds");//Tooltip of the item
+
         private int timer = 60 * 10;//10 second timer
         private const int healthPercentage = 5;
-
-        public override void SetStaticDefaults()
-        {
-            base.DisplayName.WithFormatArgs("Green Cross");//Name of the Item
-            base.Tooltip.WithFormatArgs("A Geneva-Convention-friendly pin which boasts regenerative properties.\nRegenerates 5% of your maximum health every 10 seconds");//Tooltip of the item
-        }
-
         public override void SetDefaults()
         {
             Item.width = 32;//Width of the hitbox of the item (usually the item's sprite width)

--- a/Items/Accessories/Flairs/IronCross.cs
+++ b/Items/Accessories/Flairs/IronCross.cs
@@ -7,9 +7,6 @@ namespace EBF.Items.Accessories.Flairs
 	public class IronCross : ModItem, ILocalizedModType
 	{
         public new string LocalizationCategory => "Items.Accessories";
-			//base.Tooltip.WithFormatArgs("A war medal which offers protection. Lance's favourite flair.\n4 defense\nBoosts ranged damage by 10%");//Tooltip of the item
-		
-
 		public override void SetDefaults()
 		{
 			Item.width = 32;//Width of the hitbox of the item (usually the item's sprite width)

--- a/Items/Accessories/Flairs/IronCross.cs
+++ b/Items/Accessories/Flairs/IronCross.cs
@@ -1,21 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Terraria;
+﻿using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace EBF.Items.Accessories.Flairs
 {
-	public class IronCross : ModItem
+	public class IronCross : ModItem, ILocalizedModType
 	{
-		public override void SetStaticDefaults()
-		{
-			base.DisplayName.WithFormatArgs("Iron Cross");//Name of the Item
-			base.Tooltip.WithFormatArgs("A war medal which offers protection. Lance's favourite flair.\n4 defense\nBoosts ranged damage by 10%");//Tooltip of the item
-		}
+        public new string LocalizationCategory => "Items.Accessories";
+			//base.Tooltip.WithFormatArgs("A war medal which offers protection. Lance's favourite flair.\n4 defense\nBoosts ranged damage by 10%");//Tooltip of the item
+		
 
 		public override void SetDefaults()
 		{

--- a/Items/Accessories/Flairs/ShieldMedal.cs
+++ b/Items/Accessories/Flairs/ShieldMedal.cs
@@ -1,21 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Terraria;
+﻿using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace EBF.Items.Accessories.Flairs
 {
-    public class ShieldMedal : ModItem
+    public class ShieldMedal : ModItem, ILocalizedModType
     {
-        public override void SetStaticDefaults()
-        {
-            base.DisplayName.WithFormatArgs("Shield Medal");
-            base.Tooltip.WithFormatArgs("Aid others where you can. Let all be helped and loved throughout the realm.\n20 defense");
-        }
+        public new string LocalizationCategory => "Items.Accessories";
+        //base.Tooltip.WithFormatArgs("Aid others where you can. Let all be helped and loved throughout the realm.\n20 defense");
+
         public override void SetDefaults()
         {
             Item.width = 20;

--- a/Items/Accessories/Flairs/ShieldMedal.cs
+++ b/Items/Accessories/Flairs/ShieldMedal.cs
@@ -7,8 +7,6 @@ namespace EBF.Items.Accessories.Flairs
     public class ShieldMedal : ModItem, ILocalizedModType
     {
         public new string LocalizationCategory => "Items.Accessories";
-        //base.Tooltip.WithFormatArgs("Aid others where you can. Let all be helped and loved throughout the realm.\n20 defense");
-
         public override void SetDefaults()
         {
             Item.width = 20;

--- a/Items/Accessories/Flairs/SwordMedal.cs
+++ b/Items/Accessories/Flairs/SwordMedal.cs
@@ -7,8 +7,6 @@ namespace EBF.Items.Accessories.Flairs
     public class SwordMedal : ModItem, ILocalizedModType
     {
         public new string LocalizationCategory => "Items.Accessories";
-        //base.Tooltip.WithFormatArgs("True might is the mark of discipline, honor and courage.\n Increases Ranged and Melee damage by 20%");//Tooltip of the item
-
         public override void SetDefaults()
         {
             Item.width = 32;

--- a/Items/Accessories/Flairs/SwordMedal.cs
+++ b/Items/Accessories/Flairs/SwordMedal.cs
@@ -1,21 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Terraria;
+﻿using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace EBF.Items.Accessories.Flairs
 {
-    public class SwordMedal : ModItem
+    public class SwordMedal : ModItem, ILocalizedModType
     {
-        public override void SetStaticDefaults()
-        {
-            base.DisplayName.WithFormatArgs("Sword Medal");//Name of the Item
-            base.Tooltip.WithFormatArgs("True might is the mark of discipline, honor and courage.\n Increases Ranged and Melee damage by 20%");//Tooltip of the item
-        }
+        public new string LocalizationCategory => "Items.Accessories";
+        //base.Tooltip.WithFormatArgs("True might is the mark of discipline, honor and courage.\n Increases Ranged and Melee damage by 20%");//Tooltip of the item
+
         public override void SetDefaults()
         {
             Item.width = 32;

--- a/Items/Accessories/Flairs/TargetBadge.cs
+++ b/Items/Accessories/Flairs/TargetBadge.cs
@@ -7,8 +7,6 @@ namespace EBF.Items.Accessories.Flairs
     public class TargetBadge : ModItem, ILocalizedModType
     {
         public new string LocalizationCategory => "Items.Accessories";
-        //base.Tooltip.WithFormatArgs("Somehow putting a target on yourself makes you a better shot, who knew?\nIncreases critical chance by 4%.\nIncreases enemy aggression.");//Tooltip of the item
-
         public override void SetDefaults()
         {
             Item.width = 32;//Width of the hitbox of the item (usually the item's sprite width)

--- a/Items/Accessories/Flairs/TargetBadge.cs
+++ b/Items/Accessories/Flairs/TargetBadge.cs
@@ -4,13 +4,11 @@ using Terraria.ModLoader;
 
 namespace EBF.Items.Accessories.Flairs
 {
-    public class TargetBadge : ModItem
+    public class TargetBadge : ModItem, ILocalizedModType
     {
-        public override void SetStaticDefaults()
-        {
-            base.DisplayName.WithFormatArgs("Target Badge");//Name of the Item
-            base.Tooltip.WithFormatArgs("Somehow putting a target on yourself makes you a better shot, who knew?\nIncreases critical chance by 4%.\nIncreases enemy aggression.");//Tooltip of the item
-        }
+        public new string LocalizationCategory => "Items.Accessories";
+        //base.Tooltip.WithFormatArgs("Somehow putting a target on yourself makes you a better shot, who knew?\nIncreases critical chance by 4%.\nIncreases enemy aggression.");//Tooltip of the item
+
         public override void SetDefaults()
         {
             Item.width = 32;//Width of the hitbox of the item (usually the item's sprite width)

--- a/Items/Magic/Airstrike/Airstrike.cs
+++ b/Items/Magic/Airstrike/Airstrike.cs
@@ -14,7 +14,6 @@ namespace EBF.Items.Magic.Airstrike
         public new string LocalizationCategory => "Items.Weapons.Magic";
         public override void SetStaticDefaults()
         {
-            //base.Tooltip.WithFormatArgs("Bombs away!!!!\nLeft click to quickly drop bombs down, right click to drop 3 weaker bombs at once.");//Tooltip of the item
             ItemID.Sets.ItemsThatAllowRepeatedRightClick[Item.type] = true;
         }
         public override void SetDefaults()

--- a/Items/Magic/Airstrike/Airstrike.cs
+++ b/Items/Magic/Airstrike/Airstrike.cs
@@ -1,10 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Terraria;
 using Terraria.Audio;
 using Terraria.DataStructures;
@@ -13,12 +9,12 @@ using Terraria.ModLoader;
 
 namespace EBF.Items.Magic.Airstrike
 {
-    public class Airstrike_Remote : ModItem
+    public class Airstrike_Remote : ModItem, ILocalizedModType
     {
+        public new string LocalizationCategory => "Items.Weapons.Magic";
         public override void SetStaticDefaults()
         {
-            base.DisplayName.WithFormatArgs("Airstrike Remote");//Name of the Item
-            base.Tooltip.WithFormatArgs("Bombs away!!!!\nLeft click to quickly drop bombs down, right click to drop 3 weaker bombs at once.");//Tooltip of the item
+            //base.Tooltip.WithFormatArgs("Bombs away!!!!\nLeft click to quickly drop bombs down, right click to drop 3 weaker bombs at once.");//Tooltip of the item
             ItemID.Sets.ItemsThatAllowRepeatedRightClick[Item.type] = true;
         }
         public override void SetDefaults()

--- a/Items/Magic/DarkTooth.cs
+++ b/Items/Magic/DarkTooth.cs
@@ -12,10 +12,8 @@ namespace EBF.Items.Magic
     public class DarkTooth : ModItem, ILocalizedModType
     {
         public new string LocalizationCategory => "Items.Weapons.Magic";
-            //base.Tooltip.WithFormatArgs("Ancient black magic staff used for Dark elemental magic. Creates a slowly growing black hole that explodes afterwards.\nPulls everything towards it, even the player\nConsumes Limit Break while active");//Tooltip of the item
 
         int manaDrainTimer; //Used to reduce how often mana is drained
-        
         public override void SetDefaults()
         {
             Item.width = 40;//Width of the hitbox of the item (usually the item's sprite width)

--- a/Items/Magic/DarkTooth.cs
+++ b/Items/Magic/DarkTooth.cs
@@ -9,14 +9,13 @@ using Terraria.ModLoader;
 
 namespace EBF.Items.Magic
 {
-    public class DarkTooth : ModItem
+    public class DarkTooth : ModItem, ILocalizedModType
     {
+        public new string LocalizationCategory => "Items.Weapons.Magic";
+            //base.Tooltip.WithFormatArgs("Ancient black magic staff used for Dark elemental magic. Creates a slowly growing black hole that explodes afterwards.\nPulls everything towards it, even the player\nConsumes Limit Break while active");//Tooltip of the item
+
         int manaDrainTimer; //Used to reduce how often mana is drained
-        public override void SetStaticDefaults()
-        {
-            base.DisplayName.WithFormatArgs("Dark Tooth");//Name of the Item
-            base.Tooltip.WithFormatArgs("Ancient black magic staff used for Dark elemental magic. Creates a slowly growing black hole that explodes afterwards.\nPulls everything towards it, even the player\nConsumes Limit Break while active");//Tooltip of the item
-        }
+        
         public override void SetDefaults()
         {
             Item.width = 40;//Width of the hitbox of the item (usually the item's sprite width)

--- a/Items/Magic/Flameheart/Flameheart.cs
+++ b/Items/Magic/Flameheart/Flameheart.cs
@@ -6,14 +6,13 @@ using Terraria.ModLoader;
 
 namespace EBF.Items.Magic.Flameheart
 {
-    public class Flameheart : ModItem
+    public class Flameheart : ModItem, ILocalizedModType
     {
+        public new string LocalizationCategory => "Items.Weapons.Magic";
+            //base.Tooltip.WithFormatArgs("A common but powerful staff, used by mages to scorch foes.\nEvery 3 uses, it summons a firestorm\nConsumes minor amounts of Limit Break");//Tooltip of the item
+
         int ChargeStacks = 0;
-        public override void SetStaticDefaults()
-        {
-            base.DisplayName.WithFormatArgs("Flameheart");//Name of the Item
-            base.Tooltip.WithFormatArgs("A common but powerful staff, used by mages to scorch foes.\nEvery 3 uses, it summons a firestorm\nConsumes minor amounts of Limit Break");//Tooltip of the item
-        }
+        
         public override void SetDefaults()
         {
             Item.width = 40;//Width of the hitbox of the item (usually the item's sprite width)

--- a/Items/Magic/Flameheart/Flameheart.cs
+++ b/Items/Magic/Flameheart/Flameheart.cs
@@ -9,10 +9,8 @@ namespace EBF.Items.Magic.Flameheart
     public class Flameheart : ModItem, ILocalizedModType
     {
         public new string LocalizationCategory => "Items.Weapons.Magic";
-            //base.Tooltip.WithFormatArgs("A common but powerful staff, used by mages to scorch foes.\nEvery 3 uses, it summons a firestorm\nConsumes minor amounts of Limit Break");//Tooltip of the item
 
         int ChargeStacks = 0;
-        
         public override void SetDefaults()
         {
             Item.width = 40;//Width of the hitbox of the item (usually the item's sprite width)

--- a/Items/Magic/Seraphim.cs
+++ b/Items/Magic/Seraphim.cs
@@ -12,13 +12,11 @@ using Terraria.ModLoader;
 
 namespace EBF.Items.Magic
 {
-    public class Seraphim : ModItem
+    public class Seraphim : ModItem, ILocalizedModType
     {
-        public override void SetStaticDefaults()
-        {
-            base.DisplayName.WithFormatArgs("Seraphim");//Name of the Item
-            base.Tooltip.WithFormatArgs("A glorious staff used by gorgeous angels.");//Tooltip of the item
-        }
+        public new string LocalizationCategory => "Items.Weapons.Magic";
+            //base.Tooltip.WithFormatArgs("A glorious staff used by gorgeous angels.");//Tooltip of the item
+        
         public override void SetDefaults()
         {
             Item.width = 90;//Width of the hitbox of the item (usually the item's sprite width)

--- a/Items/Magic/Seraphim.cs
+++ b/Items/Magic/Seraphim.cs
@@ -15,8 +15,6 @@ namespace EBF.Items.Magic
     public class Seraphim : ModItem, ILocalizedModType
     {
         public new string LocalizationCategory => "Items.Weapons.Magic";
-            //base.Tooltip.WithFormatArgs("A glorious staff used by gorgeous angels.");//Tooltip of the item
-        
         public override void SetDefaults()
         {
             Item.width = 90;//Width of the hitbox of the item (usually the item's sprite width)

--- a/Items/Magic/ShootingStar.cs
+++ b/Items/Magic/ShootingStar.cs
@@ -1,9 +1,4 @@
 ﻿using Microsoft.Xna.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Terraria;
 using Terraria.DataStructures;
 using Terraria.ID;
@@ -11,14 +6,11 @@ using Terraria.ModLoader;
 
 namespace EBF.Items.Magic
 {
-    public class ShootingStar : ModItem
+    public class ShootingStar : ModItem, ILocalizedModType
     {
+        public new string LocalizationCategory => "Items.Weapons.Magic";
+
         private const int spread = 250;
-        public override void SetStaticDefaults()
-        {
-            base.DisplayName.WithFormatArgs("Shooting Star");//Name of the Item
-            base.Tooltip.WithFormatArgs("");//Tooltip of the item
-        }
 
         public override void SetDefaults()
         {

--- a/Items/Magic/ShootingStar.cs
+++ b/Items/Magic/ShootingStar.cs
@@ -11,7 +11,6 @@ namespace EBF.Items.Magic
         public new string LocalizationCategory => "Items.Weapons.Magic";
 
         private const int spread = 250;
-
         public override void SetDefaults()
         {
             Item.width = 40;//Width of the hitbox of the item (usually the item's sprite width)

--- a/Items/Magic/SpellProtect.cs
+++ b/Items/Magic/SpellProtect.cs
@@ -1,18 +1,12 @@
 ﻿using EBF.Buffs;
 using EBF.Buffs.Cooldowns;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Terraria;
-using Terraria.Audio;
 using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace EBF.Items.Magic
 {
-    public class SpellProtect : ModItem
+    public class SpellProtect : ModItem, ILocalizedModType
     {
         /*public static readonly SoundStyle ProtectSound = new("EBF/Assets/Sounds/Item/Protect")
         {
@@ -20,11 +14,10 @@ namespace EBF.Items.Magic
             PitchVariance = 1f
         };*/
 
-        public override void SetStaticDefaults()
-        {
-            base.DisplayName.WithFormatArgs("Protection");//Name of the Item
-            base.Tooltip.WithFormatArgs("This spell vastly protects you from enemy attacks.\nBlocks 25% of the damage received.");//Tooltip of the item
-        }
+        public new string LocalizationCategory => "Items.Weapons.Magic";
+
+            //base.Tooltip.WithFormatArgs("This spell vastly protects you from enemy attacks.\nBlocks 25% of the damage received.");//Tooltip of the item
+        
 
         public override void SetDefaults()
         {

--- a/Items/Magic/SpellProtect.cs
+++ b/Items/Magic/SpellProtect.cs
@@ -8,17 +8,13 @@ namespace EBF.Items.Magic
 {
     public class SpellProtect : ModItem, ILocalizedModType
     {
+        public new string LocalizationCategory => "Items.Weapons.Magic";
+
         /*public static readonly SoundStyle ProtectSound = new("EBF/Assets/Sounds/Item/Protect")
         {
             Volume = 1f,
             PitchVariance = 1f
         };*/
-
-        public new string LocalizationCategory => "Items.Weapons.Magic";
-
-            //base.Tooltip.WithFormatArgs("This spell vastly protects you from enemy attacks.\nBlocks 25% of the damage received.");//Tooltip of the item
-        
-
         public override void SetDefaults()
         {
             Item.width = 28;

--- a/Items/Magic/SpellRegeneration.cs
+++ b/Items/Magic/SpellRegeneration.cs
@@ -1,23 +1,16 @@
 ﻿using EBF.Buffs;
 using EBF.Buffs.Cooldowns;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace EBF.Items.Magic
 {
-    public class SpellRegeneration : ModItem
+    public class SpellRegeneration : ModItem, ILocalizedModType
     {
-        public override void SetStaticDefaults()
-        {
-            base.DisplayName.WithFormatArgs("Regeneration Spell");
-            base.Tooltip.WithFormatArgs("This spell vastly increases your regeneration.\nCosts a lot of mana and has a big cooldown.");
-        }
+        public new string LocalizationCategory => "Items.Weapons.Magic";
+           // base.Tooltip.WithFormatArgs("This spell vastly increases your regeneration.\nCosts a lot of mana and has a big cooldown.");
+        
         public override void SetDefaults()
         {
             Item.width = 28;

--- a/Items/Magic/SpellRegeneration.cs
+++ b/Items/Magic/SpellRegeneration.cs
@@ -9,8 +9,6 @@ namespace EBF.Items.Magic
     public class SpellRegeneration : ModItem, ILocalizedModType
     {
         public new string LocalizationCategory => "Items.Weapons.Magic";
-           // base.Tooltip.WithFormatArgs("This spell vastly increases your regeneration.\nCosts a lot of mana and has a big cooldown.");
-        
         public override void SetDefaults()
         {
             Item.width = 28;

--- a/Items/Melee/Anarchy.cs
+++ b/Items/Melee/Anarchy.cs
@@ -1,23 +1,15 @@
 ﻿using Microsoft.Xna.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace EBF.Items.Melee
 {
-    public class Anarchy : ModItem
+    public class Anarchy : ModItem, ILocalizedModType
     {
-        public override void SetStaticDefaults()
-        {
-            base.DisplayName.WithFormatArgs("Anarchy");//Name of the Item
-            base.Tooltip.WithFormatArgs("Reduced defense while held.\nGrows stronger at low health.\n'It's gonna be worth it'");//Tooltip of the item
-        }
-
+        public new string LocalizationCategory => "Items.Weapons.Melee";
+            //base.Tooltip.WithFormatArgs("Reduced defense while held.\nGrows stronger at low health.\n'It's gonna be worth it'");//Tooltip of the item
+        
         public override void SetDefaults()
         {
             Item.width = 112;//Width of the hitbox of the item (usually the item's sprite width)
@@ -37,7 +29,6 @@ namespace EBF.Items.Melee
             Item.autoReuse = true;//Boolean, if the item auto reuses if the use button is held
             Item.useTurn = false;//Boolean, if the player's direction can change while using the item
         }
-
         public override void AddRecipes()
         {
             //Recipe that creates this item
@@ -47,7 +38,6 @@ namespace EBF.Items.Melee
                 .AddTile(TileID.MythrilAnvil)
                 .Register();
         }
-
         public override void MeleeEffects(Player player, Rectangle hitbox)
         {
             if (player.statLife <= player.statLifeMax / 2)
@@ -58,7 +48,6 @@ namespace EBF.Items.Melee
                 }
             }
         }
-
         public override void ModifyWeaponDamage(Player player, ref StatModifier damage)
         {
             //Boost damage at half health
@@ -67,7 +56,6 @@ namespace EBF.Items.Melee
                 damage *= 1.5f;
             }
         }
-
         public override void HoldItem(Player player)
         {
             //75% defense while held

--- a/Items/Melee/Anarchy.cs
+++ b/Items/Melee/Anarchy.cs
@@ -8,8 +8,6 @@ namespace EBF.Items.Melee
     public class Anarchy : ModItem, ILocalizedModType
     {
         public new string LocalizationCategory => "Items.Weapons.Melee";
-            //base.Tooltip.WithFormatArgs("Reduced defense while held.\nGrows stronger at low health.\n'It's gonna be worth it'");//Tooltip of the item
-        
         public override void SetDefaults()
         {
             Item.width = 112;//Width of the hitbox of the item (usually the item's sprite width)

--- a/Items/Melee/Avenger.cs
+++ b/Items/Melee/Avenger.cs
@@ -8,11 +8,7 @@ namespace EBF.Items.Melee
     {
         public new string LocalizationCategory => "Items.Weapons.Melee";
 
-        int missHP;//The missing health of the player
-
-            //base.Tooltip.WithFormatArgs("For every scar, for every dishonor, the Avenger sharpens its edge. Grows stronger at low health.");//Tooltip of the item
-        
-
+        int missHP; //The missing health of the player
         public override void SetDefaults()
         {
             Item.width = 48;//Width of the hitbox of the item (usually the item's sprite width)

--- a/Items/Melee/Avenger.cs
+++ b/Items/Melee/Avenger.cs
@@ -1,22 +1,17 @@
-﻿using System;
-using Terraria;
+﻿using Terraria;
 using Terraria.ModLoader;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Terraria.ID;
 
 namespace EBF.Items.Melee
 {
-    public class Avenger : ModItem
+    public class Avenger : ModItem, ILocalizedModType
     {
+        public new string LocalizationCategory => "Items.Weapons.Melee";
+
         int missHP;//The missing health of the player
-        public override void SetStaticDefaults()
-        {
-            base.DisplayName.WithFormatArgs("Avenger");//Name of the Item
-            base.Tooltip.WithFormatArgs("For every scar, for every dishonor, the Avenger sharpens its edge. Grows stronger at low health.");//Tooltip of the item
-        }
+
+            //base.Tooltip.WithFormatArgs("For every scar, for every dishonor, the Avenger sharpens its edge. Grows stronger at low health.");//Tooltip of the item
+        
 
         public override void SetDefaults()
         {
@@ -37,7 +32,6 @@ namespace EBF.Items.Melee
             Item.autoReuse = true;//Boolean, if the item auto reuses if the use button is held
             Item.useTurn = true;//Boolean, if the player's direction can change while using the item
         }
-
         public override void HoldItem(Player player)
         {
             //Making the sword's damage increase based on the missing health
@@ -48,9 +42,6 @@ namespace EBF.Items.Melee
                 Item.damage = 1 + (int)(missHP / 2);
             }
         }
-
-        /*TODO: Remove recipe and add this sword to the Matt NPC's shop
-         */
         public override void AddRecipes()
         {
             CreateRecipe()

--- a/Items/Melee/Berzerker.cs
+++ b/Items/Melee/Berzerker.cs
@@ -1,21 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Terraria;
+﻿using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace EBF.Items.Melee
 {
-    public class Berzerker : ModItem
+    public class Berzerker : ModItem, ILocalizedModType
     {
-        public override void SetStaticDefaults()
-        {
-            base.DisplayName.WithFormatArgs("Berzerker");//Name of the Item
-            base.Tooltip.WithFormatArgs("");//Tooltip of the item
-        }
+        public new string LocalizationCategory => "Items.Weapons.Melee";
 
         public override void SetDefaults()
         {

--- a/Items/Melee/Berzerker.cs
+++ b/Items/Melee/Berzerker.cs
@@ -7,7 +7,6 @@ namespace EBF.Items.Melee
     public class Berzerker : ModItem, ILocalizedModType
     {
         public new string LocalizationCategory => "Items.Weapons.Melee";
-
         public override void SetDefaults()
         {
             Item.width = 64;//Width of the hitbox of the item (usually the item's sprite width)

--- a/Items/Melee/BlackFang.cs
+++ b/Items/Melee/BlackFang.cs
@@ -1,22 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Terraria;
+﻿using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace EBF.Items.Melee
 {
-	public class BlackFang : ModItem
+	public class BlackFang : ModItem, ILocalizedModType
 	{
-		public override void SetStaticDefaults()
-		{
-			base.DisplayName.WithFormatArgs("Black Fang");//Name of the Item
-			base.Tooltip.WithFormatArgs("'This weapon is totally historically accurate, I'm sure of it. I saw it in an anime once!' - Matt");//Tooltip of the item
-		}
+        public new string LocalizationCategory => "Items.Weapons.Melee";
 
+			//base.Tooltip.WithFormatArgs("'This weapon is totally historically accurate, I'm sure of it. I saw it in an anime once!' - Matt");//Tooltip of the item
+		
 		public override void SetDefaults()
 		{
 			Item.width = 82;//Width of the hitbox of the item (usually the item's sprite width)
@@ -47,7 +40,6 @@ namespace EBF.Items.Melee
 				player.HealEffect(HealthHeal);
 			}
 		}
-
         public override void AddRecipes()
         {
 			CreateRecipe(amount: 1)

--- a/Items/Melee/BlackFang.cs
+++ b/Items/Melee/BlackFang.cs
@@ -7,9 +7,6 @@ namespace EBF.Items.Melee
 	public class BlackFang : ModItem, ILocalizedModType
 	{
         public new string LocalizationCategory => "Items.Weapons.Melee";
-
-			//base.Tooltip.WithFormatArgs("'This weapon is totally historically accurate, I'm sure of it. I saw it in an anime once!' - Matt");//Tooltip of the item
-		
 		public override void SetDefaults()
 		{
 			Item.width = 82;//Width of the hitbox of the item (usually the item's sprite width)

--- a/Items/Melee/Blizzard.cs
+++ b/Items/Melee/Blizzard.cs
@@ -1,9 +1,4 @@
 ﻿using Microsoft.Xna.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Terraria;
 using Terraria.DataStructures;
 using Terraria.ID;
@@ -14,8 +9,6 @@ namespace EBF.Items.Melee
     public class Blizzard : ModItem, ILocalizedModType
     {
         public new string LocalizationCategory => "Items.Weapons.Melee";
-           // base.Tooltip.WithFormatArgs("Shoots an additional bolt of frost at the cost of some accuracy.");//Tooltip of the item
-        
         public override void SetDefaults()
         {
             Item.width = 88;//Width of the hitbox of the item (usually the item's sprite width)

--- a/Items/Melee/Blizzard.cs
+++ b/Items/Melee/Blizzard.cs
@@ -11,14 +11,11 @@ using Terraria.ModLoader;
 
 namespace EBF.Items.Melee
 {
-    public class Blizzard : ModItem
+    public class Blizzard : ModItem, ILocalizedModType
     {
-        public override void SetStaticDefaults()
-        {
-            base.DisplayName.WithFormatArgs("Blizzard");//Name of the Item
-            base.Tooltip.WithFormatArgs("Shoots an additional bolt of frost at the cost of some accuracy.");//Tooltip of the item
-        }
-
+        public new string LocalizationCategory => "Items.Weapons.Melee";
+           // base.Tooltip.WithFormatArgs("Shoots an additional bolt of frost at the cost of some accuracy.");//Tooltip of the item
+        
         public override void SetDefaults()
         {
             Item.width = 88;//Width of the hitbox of the item (usually the item's sprite width)

--- a/Items/Melee/BloodBlade.cs
+++ b/Items/Melee/BloodBlade.cs
@@ -7,9 +7,6 @@ namespace EBF.Items.Melee
 	public class BloodBlade : ModItem, ILocalizedModType
 	{
         public new string LocalizationCategory => "Items.Weapons.Melee";
-
-			//base.Tooltip.WithFormatArgs("Drains the health of hit targets");//Tooltip of the item
-
 		public override void SetDefaults()
 		{
 			Item.width = 82;//Width of the hitbox of the item (usually the item's sprite width)

--- a/Items/Melee/BloodBlade.cs
+++ b/Items/Melee/BloodBlade.cs
@@ -4,13 +4,11 @@ using Terraria.ModLoader;
 
 namespace EBF.Items.Melee
 {
-	public class BloodBlade : ModItem
+	public class BloodBlade : ModItem, ILocalizedModType
 	{
-		public override void SetStaticDefaults()
-		{
-			base.DisplayName.WithFormatArgs("Blood Blade");//Name of the Item
-			base.Tooltip.WithFormatArgs("Drains the health of hit targets");//Tooltip of the item
-		}
+        public new string LocalizationCategory => "Items.Weapons.Melee";
+
+			//base.Tooltip.WithFormatArgs("Drains the health of hit targets");//Tooltip of the item
 
 		public override void SetDefaults()
 		{
@@ -39,9 +37,6 @@ namespace EBF.Items.Melee
 				player.HealEffect(HealthHeal);
 			}
 		}
-
-		/*TODO: Remove recipe and add it to the Matt NPC's shop
-		 */
         public override void AddRecipes()
         {
 			CreateRecipe(amount: 1)

--- a/Items/Melee/DeathScythe.cs
+++ b/Items/Melee/DeathScythe.cs
@@ -11,13 +11,9 @@ using Microsoft.Xna.Framework;
 
 namespace EBF.Items.Melee
 {
-    public class DeathScythe : ModItem
+    public class DeathScythe : ModItem, ILocalizedModItem
     {
-        public override void SetStaticDefaults()
-        {
-            base.DisplayName.WithFormatArgs("Death Scythe");//Name of the Item
-            base.Tooltip.WithFormatArgs("");//Tooltip of the item
-        }
+        public new string LocalizationCategory => "Items.Weapons.Magic";
 
         public override void SetDefaults()
         {

--- a/Items/Melee/DragonsFeather.cs
+++ b/Items/Melee/DragonsFeather.cs
@@ -1,21 +1,14 @@
-﻿using Microsoft.Xna.Framework;
-using Terraria;
-using Terraria.DataStructures;
+﻿using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace EBF.Items.Melee
 {
-    public class DragonsFeather : ModItem
+    public class DragonsFeather : ModItem, ILocalizedModType
     {
+        public new string LocalizationCategory => "Items.Weapons.Melee";
+
         private int swings = 0;
-
-        public override void SetStaticDefaults()
-        {
-            base.DisplayName.WithFormatArgs("Dragon's Feather");//Name of the Item
-            base.Tooltip.WithFormatArgs("");//Tooltip of the item
-        }
-
         public override void SetDefaults()
         {
             Item.width = 64;//Width of the hitbox of the item (usually the item's sprite width)
@@ -33,33 +26,12 @@ namespace EBF.Items.Melee
             Item.UseSound = SoundID.Item1;//The item's sound when it's used
             Item.autoReuse = true;//Boolean, if the item auto reuses if the use button is held
             Item.useTurn = false;//Boolean, if the player's direction can change while using the item
-
-            //Item.shoot = ProjectileID.TerraBeam;
-            //Item.shootSpeed = 10;
         }
-
-        /* TODO: Find a good projectile for this weapon, something short range.
-         * Also, we need to find a way to increase player movement speed without giving a buff, otherwise it might cancel existing buffs when unheld.
-         */
-
-        //public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
-        //{
-        //    swings++;
-        //    if (swings >= 3)
-        //    {
-        //        Projectile.NewProjectile(source, position, velocity, type, damage, knockback);
-        //        swings = 0;
-        //    }
-
-        //    return false;
-        //}
-
         public override void HoldItem(Player player)
         {
             player.AddBuff(BuffID.Swiftness, 1);
             player.AddBuff(BuffID.Sunflower, 1);
         }
-
         public override void AddRecipes()
         {
             CreateRecipe()

--- a/Items/Melee/FusionBlade.cs
+++ b/Items/Melee/FusionBlade.cs
@@ -10,10 +10,7 @@ namespace EBF.Items.Melee
 {
     public class FusionBlade : ModItem, ILocalizedModType
     {
-        public new string LocalizationCategory => "Items.Weapons.Melee";
-
-            //base.Tooltip.WithFormatArgs("Modeled after the weapons used by the MILITIA branch.\nShoots a big bullet.");//Tooltip of the item
-        
+        public new string LocalizationCategory => "Items.Weapons.Melee";        
         public override void SetDefaults()
         {
             Item.width = 64;//Width of the hitbox of the item (usually the item's sprite width)

--- a/Items/Melee/FusionBlade.cs
+++ b/Items/Melee/FusionBlade.cs
@@ -1,10 +1,6 @@
 ﻿using EBF.Extensions;
 using Microsoft.Xna.Framework;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Terraria;
 using Terraria.DataStructures;
 using Terraria.ID;
@@ -12,13 +8,12 @@ using Terraria.ModLoader;
 
 namespace EBF.Items.Melee
 {
-    public class FusionBlade : ModItem
+    public class FusionBlade : ModItem, ILocalizedModType
     {
-        public override void SetStaticDefaults()
-        {
-            base.DisplayName.WithFormatArgs("Fusion Blade");//Name of the Item
-            base.Tooltip.WithFormatArgs("Modeled after the weapons used by the MILITIA branch.\nShoots a big bullet.");//Tooltip of the item
-        }
+        public new string LocalizationCategory => "Items.Weapons.Melee";
+
+            //base.Tooltip.WithFormatArgs("Modeled after the weapons used by the MILITIA branch.\nShoots a big bullet.");//Tooltip of the item
+        
         public override void SetDefaults()
         {
             Item.width = 64;//Width of the hitbox of the item (usually the item's sprite width)

--- a/Items/Melee/HeavensGate.cs
+++ b/Items/Melee/HeavensGate.cs
@@ -7,13 +7,12 @@ using Terraria.ModLoader;
 
 namespace EBF.Items.Melee
 {
-    public class HeavensGate : ModItem
+    public class HeavensGate : ModItem, ILocalizedModType
     {
-        public override void SetStaticDefaults()
-        {
-            base.DisplayName.WithFormatArgs("Heaven's Gate");//Name of the Item
-            base.Tooltip.WithFormatArgs("A legendary sword belonging to a line of famed corsairs.");//Tooltip of the item
-        }
+        public new string LocalizationCategory => "Items.Weapons.Melee";
+
+            //A legendary sword belonging to a line of famed corsairs.
+        
         public override void SetDefaults()
         {
             Item.width = 64;//Width of the hitbox of the item (usually the item's sprite width)

--- a/Items/Melee/HeavensGate.cs
+++ b/Items/Melee/HeavensGate.cs
@@ -10,9 +10,6 @@ namespace EBF.Items.Melee
     public class HeavensGate : ModItem, ILocalizedModType
     {
         public new string LocalizationCategory => "Items.Weapons.Melee";
-
-            //A legendary sword belonging to a line of famed corsairs.
-        
         public override void SetDefaults()
         {
             Item.width = 64;//Width of the hitbox of the item (usually the item's sprite width)

--- a/Items/Melee/Inferno.cs
+++ b/Items/Melee/Inferno.cs
@@ -9,7 +9,6 @@ namespace EBF.Items.Melee
     public class Inferno : ModItem, ILocalizedModType
     {
         public new string LocalizationCategory => "Items.Weapons.Melee";
-        //Wreathed in scorching flames. Burns foes.
         public override void SetDefaults()
         {
             Item.width = 60;//Width of the hitbox of the item (usually the item's sprite width)

--- a/Items/Melee/Inferno.cs
+++ b/Items/Melee/Inferno.cs
@@ -1,22 +1,15 @@
 ﻿using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
 using Terraria;
 using Terraria.DataStructures;
-using Terraria.GameContent;
 using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace EBF.Items.Melee
 {
-    public class Inferno : ModItem
+    public class Inferno : ModItem, ILocalizedModType
     {
-
-        public override void SetStaticDefaults()
-        {
-            base.DisplayName.WithFormatArgs("Inferno");//Name of the Item
-            base.Tooltip.WithFormatArgs("Wreathed in scorching flames.\nBurns foes.");//Tooltip of the item
-        }
-
+        public new string LocalizationCategory => "Items.Weapons.Melee";
+        //Wreathed in scorching flames. Burns foes.
         public override void SetDefaults()
         {
             Item.width = 60;//Width of the hitbox of the item (usually the item's sprite width)

--- a/Items/Melee/LoveBlade.cs
+++ b/Items/Melee/LoveBlade.cs
@@ -1,21 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Terraria;
+﻿using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace EBF.Items.Melee
 {
-    public class LoveBlade : ModItem
+    public class LoveBlade : ModItem, ILocalizedModType
     {
-        public override void SetStaticDefaults()
-        {
-            base.DisplayName.WithFormatArgs("Love Blade");//Name of the Item
-            base.Tooltip.WithFormatArgs("");//Tooltip of the item
-        }
+        public new string LocalizationCategory => "Items.Weapons.Melee";
         public override void SetDefaults()
         {
             Item.width = 64;//Width of the hitbox of the item (usually the item's sprite width)

--- a/Items/Melee/SoulEater.cs
+++ b/Items/Melee/SoulEater.cs
@@ -1,9 +1,4 @@
 ﻿using Microsoft.Xna.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Terraria;
 using Terraria.DataStructures;
 using Terraria.ID;
@@ -11,14 +6,10 @@ using Terraria.ModLoader;
 
 namespace EBF.Items.Melee
 {
-    public class SoulEater : ModItem
+    public class SoulEater : ModItem, ILocalizedModType
     {
-        public override void SetStaticDefaults()
-        {
-            base.DisplayName.WithFormatArgs("Soul Eater");//Name of the Item
-            base.Tooltip.WithFormatArgs("Deals massive damage but reduces your defense by 50% when held.\nHonestly, it could have been worse. It could kill you instantly.");//Tooltip of the item
-        }
-
+        public new string LocalizationCategory => "Items.Weapons.Melee";
+        //Deals massive damage but reduces your defense by 50% when held.\nHonestly, it could have been worse. It could kill you instantly.
         public override void SetDefaults()
         {
             Item.width = 62;//Width of the hitbox of the item (usually the item's sprite width)

--- a/Items/Melee/SoulEater.cs
+++ b/Items/Melee/SoulEater.cs
@@ -9,7 +9,6 @@ namespace EBF.Items.Melee
     public class SoulEater : ModItem, ILocalizedModType
     {
         public new string LocalizationCategory => "Items.Weapons.Melee";
-        //Deals massive damage but reduces your defense by 50% when held.\nHonestly, it could have been worse. It could kill you instantly.
         public override void SetDefaults()
         {
             Item.width = 62;//Width of the hitbox of the item (usually the item's sprite width)

--- a/Items/Melee/Spears/GiantSlayer.cs
+++ b/Items/Melee/Spears/GiantSlayer.cs
@@ -1,9 +1,4 @@
 ﻿using Microsoft.Xna.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Terraria;
 using Terraria.DataStructures;
 using Terraria.ID;
@@ -11,13 +6,9 @@ using Terraria.ModLoader;
 
 namespace EBF.Items.Melee.Spears
 {
-    public class GiantSlayer : ModItem
+    public class GiantSlayer : ModItem, ILocalizedModType
     {
-        public override void SetStaticDefaults()
-        {
-            base.DisplayName.WithFormatArgs("Giant Slayer");//Name of the Item
-        }
-
+        public new string LocalizationCategory => "Items.Weapons.Melee";
         public override void SetDefaults()
         {
             Item.damage = 40;
@@ -36,13 +27,10 @@ namespace EBF.Items.Melee.Spears
             Item.noUseGraphic = true; // Important, it's kind of wired if people see two spears at one time. This prevents the melee animation of this Item.
             Item.shoot = ModContent.ProjectileType<GiantSlayer_Projectile>();
         }
-
-
         public override void HoldItem(Player player)
         {
             player.GetArmorPenetration(DamageClass.Melee) += 100;
         }
-
         public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback)
         {
             Vector2 muzzleOffset = Vector2.Normalize(new Vector2(velocity.X, velocity.Y)) * 25f;

--- a/Items/Melee/SwiftBrand.cs
+++ b/Items/Melee/SwiftBrand.cs
@@ -1,21 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Terraria;
+﻿using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace EBF.Items.Melee
 {
-    public class SwiftBrand : ModItem
+    public class SwiftBrand : ModItem, ILocalizedModType
     {
-        public override void SetStaticDefaults()
-        {
-            base.DisplayName.WithFormatArgs("Swift Brand");//Name of the Item
-            base.Tooltip.WithFormatArgs("'It's so easy to swing around!' - Matt");//Tooltip of the item
-        }
+        public new string LocalizationCategory => "Items.Weapons.Melee";
+        //'It's so easy to swing around!' - Matt
 
         public override void SetDefaults()
         {

--- a/Items/Melee/SwiftBrand.cs
+++ b/Items/Melee/SwiftBrand.cs
@@ -7,8 +7,6 @@ namespace EBF.Items.Melee
     public class SwiftBrand : ModItem, ILocalizedModType
     {
         public new string LocalizationCategory => "Items.Weapons.Melee";
-        //'It's so easy to swing around!' - Matt
-
         public override void SetDefaults()
         {
             Item.width = 64;//Width of the hitbox of the item (usually the item's sprite width)

--- a/Items/Melee/SwordBreaker.cs
+++ b/Items/Melee/SwordBreaker.cs
@@ -5,16 +5,12 @@ using Terraria.ModLoader;
 
 namespace EBF.Items.Melee
 {
-    public class SwordBreaker : ModItem
+    public class SwordBreaker : ModItem, ILocalizedModType
     {
+        public new string LocalizationCategory => "Items.Weapons.Melee";
+        //Applies weak to hit targets
+
         private const int debuffDuration = 15; //In seconds
-
-        public override void SetStaticDefaults()
-        {
-            base.DisplayName.WithFormatArgs("Sword Breaker");//Name of the Item
-            base.Tooltip.WithFormatArgs("Applies Weak to hit targets.");//Tooltip of the item
-        }
-
         public override void SetDefaults()
         {
             Item.width = 80;//Width of the hitbox of the item (usually the item's sprite width)

--- a/Items/Melee/SwordBreaker.cs
+++ b/Items/Melee/SwordBreaker.cs
@@ -8,7 +8,6 @@ namespace EBF.Items.Melee
     public class SwordBreaker : ModItem, ILocalizedModType
     {
         public new string LocalizationCategory => "Items.Weapons.Melee";
-        //Applies weak to hit targets
 
         private const int debuffDuration = 15; //In seconds
         public override void SetDefaults()

--- a/Items/Melee/Throwable/IceNeedle.cs
+++ b/Items/Melee/Throwable/IceNeedle.cs
@@ -10,12 +10,10 @@ using Terraria.ModLoader;
 
 namespace EBF.Items.Melee.Throwable
 {
-    public class IceNeedle : ModItem
+    public class IceNeedle : ModItem, ILocalizedModType
     {
-        public override void SetStaticDefaults()
-        {
-            base.DisplayName.WithFormatArgs("Ice Needle");//Name of the Item
-        }
+        public new string LocalizationCategory => "Items.Weapons.Melee";
+
         public override void SetDefaults()
         {
             Item.width = 72;

--- a/Items/Melee/Throwable/IceNeedle.cs
+++ b/Items/Melee/Throwable/IceNeedle.cs
@@ -13,7 +13,6 @@ namespace EBF.Items.Melee.Throwable
     public class IceNeedle : ModItem, ILocalizedModType
     {
         public new string LocalizationCategory => "Items.Weapons.Melee";
-
         public override void SetDefaults()
         {
             Item.width = 72;

--- a/Items/Melee/UltraPro9000X.cs
+++ b/Items/Melee/UltraPro9000X.cs
@@ -5,13 +5,11 @@ using Terraria.ModLoader;
 
 namespace EBF.Items.Melee
 {
-    public class UltraPro9000X : ModItem
+    public class UltraPro9000X : ModItem, ILocalizedModType
     {
-        public override void SetStaticDefaults()
-        {
-            base.DisplayName.WithFormatArgs("Ultra Pro 9000 X");//Name of the Item
-            base.Tooltip.WithFormatArgs("'I can use this old hockey stick as a weapon. I think that should be enough equipment for now.' - Matt");//Tooltip of the item
-        }
+        public new string LocalizationCategory => "Items.Weapons.Melee";
+
+        //'I can use this old hockey stick as a weapon. I think that should be enough equipment for now.' - Matt
 
         public override void SetDefaults()
         {

--- a/Items/Melee/UltraPro9000X.cs
+++ b/Items/Melee/UltraPro9000X.cs
@@ -8,9 +8,6 @@ namespace EBF.Items.Melee
     public class UltraPro9000X : ModItem, ILocalizedModType
     {
         public new string LocalizationCategory => "Items.Weapons.Melee";
-
-        //'I can use this old hockey stick as a weapon. I think that should be enough equipment for now.' - Matt
-
         public override void SetDefaults()
         {
             Item.width = 116;//Width of the hitbox of the item (usually the item's sprite width)

--- a/Items/Ranged/CrimsonDragon.cs
+++ b/Items/Ranged/CrimsonDragon.cs
@@ -5,13 +5,9 @@ using Terraria.ModLoader;
 
 namespace EBF.Items.Ranged
 {
-    public class CrimsonDragon : ModItem
+    public class CrimsonDragon : ModItem, ILocalizedModType
     {
-        public override void SetStaticDefaults()
-        {
-            base.DisplayName.WithFormatArgs("Crimson Dragon");//Name of the Item
-            base.Tooltip.WithFormatArgs("");//Tooltip of the item
-        }
+        public new string LocalizationCategory => "Items.Weapons.Ranged";
 
         public override void SetDefaults()
         {

--- a/Items/Ranged/CrimsonDragon.cs
+++ b/Items/Ranged/CrimsonDragon.cs
@@ -8,7 +8,6 @@ namespace EBF.Items.Ranged
     public class CrimsonDragon : ModItem, ILocalizedModType
     {
         public new string LocalizationCategory => "Items.Weapons.Ranged";
-
         public override void SetDefaults()
         {
             Item.width = 26;//Width of the hitbox of the item (usually the item's sprite width)
@@ -32,7 +31,6 @@ namespace EBF.Items.Ranged
             Item.shootSpeed = 10f;
 
         }
-
         public override void ModifyShootStats(Player player, ref Vector2 position, ref Vector2 velocity, ref int type, ref int damage, ref float knockback)
         {
             if (type == ProjectileID.WoodenArrowFriendly)

--- a/Localization/en-US_Mods.EBF.hjson
+++ b/Localization/en-US_Mods.EBF.hjson
@@ -39,254 +39,6 @@ Buffs: {
 	}
 }
 
-Items: {
-	AngryFaic: {
-		DisplayName: Angry Faic
-		Tooltip:
-			'''
-			Wearing this makes you so angry, you want something to be BLAMMED!
-			2 defense
-			Increases critical chance by 8% for all types of damage.
-			Increases damage by 8%.
-			Increases enemy aggression.
-			'''
-	}
-
-	BalanceBadge: {
-		DisplayName: Balance Badge
-		Tooltip:
-			'''
-			Represents pure equilibrium and bestows a wealth of boosts.
-			5 defense
-			5% increase to all damage types
-			Increases maximum health and mana by 10
-			Increases movement and attack speed by 5%
-			Increases max minion slots by 1
-			Increases critical rates by 5%
-			'''
-	}
-
-	GreenCross: {
-		DisplayName: Green Cross
-		Tooltip: A Geneva-Convention-friendly pin which boasts regenerative properties.\nRegenerates 5% of your maximum health every 10 seconds
-	}
-
-	IronCross: {
-		DisplayName: Iron Cross
-		Tooltip:
-			'''
-			A war medal which offers protection. Lance's favourite flair.
-			4 defense
-			Boosts ranged damage by 10%
-			'''
-	}
-
-	ShieldMedal: {
-		DisplayName: Shield Medal
-		Tooltip:
-			'''
-			Aid others where you can. Let all be helped and loved throughout the realm.
-			20 defense
-			'''
-	}
-
-	SwordMedal: {
-		DisplayName: Sword Medal
-		Tooltip:
-			'''
-			True might is the mark of discipline, honor and courage.
-			 Increases Ranged and Melee damage by 20%
-			'''
-	}
-
-	TargetBadge: {
-		DisplayName: Target Badge
-		Tooltip:
-			'''
-			Somehow putting a target on yourself makes you a better shot, who knew?
-			1 defense
-			Increases critical chance by 10% for all types of damage.
-			Increases enemy aggression.
-			'''
-	}
-
-	DarkTooth: {
-		DisplayName: Dark Tooth
-		Tooltip:
-			'''
-			Ancient black magic staff used for Dark elemental magic. Creates a slowly growing black hole that explodes afterwards.
-			Pulls everything towards it, even the player
-			'''
-	}
-
-	Flameheart: {
-		DisplayName: Flameheart
-		Tooltip:
-			'''
-			A common but powerful staff, used by mages to scorch foes.
-			Every 3 uses, it summons a firestorm
-			Consumes minor amounts of Limit Break
-			'''
-	}
-
-	Seraphim: {
-		DisplayName: Seraphim
-		Tooltip: A glorious staff used by gorgeous angels.
-	}
-
-	SpellProtect: {
-		DisplayName: Spell Protect
-		Tooltip:
-			'''
-			This spell vastly protects you from enemy attacks.
-			Blocks 25% of the damage received.
-			'''
-	}
-
-	SpellRegeneration: {
-		DisplayName: Spell Regeneration
-		Tooltip:
-			'''
-			This spell vastly increases your regeneration.
-			Costs a lot of mana and has a big cooldown.
-			'''
-	}
-
-	Avenger: {
-		DisplayName: Avenger
-		Tooltip: For every scar, for every dishonor, the Avenger sharpens its edge. Grows stronger at low health.
-	}
-
-	BlackFang: {
-		DisplayName: Black Fang
-		Tooltip: "'This weapon is totally historically accurate, I'm sure of it. I saw it in an anime once!' - Matt"
-	}
-
-	DragonsFeather: {
-		DisplayName: Dragons Feather
-		Tooltip:
-			'''
-			A blade that grants swiftness to its wielder.
-			It can send enemies flying far away.
-			'''
-	}
-
-	HeavensGate: {
-		DisplayName: Heavens Gate
-		Tooltip: A legendary sword belonging to a line of famed corsairs.
-	}
-
-	Inferno: {
-		DisplayName: Inferno
-		Tooltip:
-			'''
-			Wreathed in scorching flames.
-			Burns foes.
-			'''
-	}
-
-	SoulEater: {
-		DisplayName: Soul Eater
-		Tooltip:
-			'''
-			Honestly, it could have been worse. It could kill you instantly.
-			When held, increases your damage by 80% but reduces your defenst by 50%.
-			'''
-	}
-
-	UltraPro9000X: {
-		DisplayName: Ultra Pro9000 X
-		Tooltip: ""
-	}
-
-	FusionBlade: {
-		DisplayName: Fusion Blade
-		Tooltip:
-			'''
-			Modeled after the weapons used by the MILITIA branch.
-			Shoots a big bullet.
-			'''
-	}
-
-	Airstrike_Remote: {
-		DisplayName: Airstrike Remote
-		Tooltip:
-			'''
-			Bombs away!!!!
-			Left click to quickly drop bombs down, right click to drop 3 weaker bombs at once.
-			'''
-	}
-
-	IceNeedle: {
-		DisplayName: Ice Needle
-		Tooltip:
-			'''
-			Cold to the tip
-			Shoots a javelin that spawns snowflakes at the impact position.
-			'''
-	}
-
-	GiantSlayer: {
-		DisplayName: Giant Slayer
-		Tooltip:
-			'''
-			A sizable spear that bests foes through sheer weight and power.
-			Permanently reduces the target's defense stat
-			Has big reach.
-			'''
-	}
-
-	BlitzNeedle: {
-		DisplayName: Blitz Needle
-		Tooltip: ""
-	}
-
-	ShootingStar: {
-		DisplayName: Shooting Star
-		Tooltip: ""
-	}
-
-	CrimsonDragon: {
-		DisplayName: Crimson Dragon
-		Tooltip: ""
-	}
-
-	Berzerker: {
-		DisplayName: Berzerker
-		Tooltip: ""
-	}
-
-	LoveBlade: {
-		DisplayName: Love Blade
-		Tooltip: ""
-	}
-
-	SwiftBrand: {
-		DisplayName: Swift Brand
-		Tooltip: ""
-	}
-
-	SwordBreaker: {
-		DisplayName: Sword Breaker
-		Tooltip: ""
-	}
-
-	Anarchy: {
-		DisplayName: Anarchy
-		Tooltip: ""
-	}
-
-	Blizzard: {
-		DisplayName: Blizzard
-		Tooltip: ""
-	}
-
-	BloodBlade: {
-		DisplayName: Blood Blade
-		Tooltip: ""
-	}
-}
-
 Projectiles: {
 	DarkTooth_BlackHole.DisplayName: Dark Tooth_ Black Hole
 	Flameheart_Fireball.DisplayName: Flameheart_ Fireball
@@ -345,4 +97,176 @@ NPCs: {
 	ObsidianIdol_1.DisplayName: Obsidian Idol_1
 	ObsidianIdol_2.DisplayName: Obsidian Idol_2
 	ObsidianIdol_3.DisplayName: Obsidian Idol_3
+}
+
+Items: {
+	Weapons: {
+		Melee: {
+			Berzerker: {
+				Tooltip: ""
+				DisplayName: Berzerker
+			}
+
+			Avenger: {
+				Tooltip: ""
+				DisplayName: Avenger
+			}
+
+			Anarchy: {
+				Tooltip: ""
+				DisplayName: Anarchy
+			}
+
+			BlackFang: {
+				DisplayName: Black Fang
+				Tooltip: ""
+			}
+
+			Blizzard: {
+				DisplayName: Blizzard
+				Tooltip: ""
+			}
+
+			BloodBlade: {
+				DisplayName: Blood Blade
+				Tooltip: ""
+			}
+
+			DragonsFeather: {
+				DisplayName: Dragons Feather
+				Tooltip: ""
+			}
+
+			FusionBlade: {
+				DisplayName: Fusion Blade
+				Tooltip: ""
+			}
+
+			HeavensGate: {
+				DisplayName: Heavens Gate
+				Tooltip: ""
+			}
+
+			Inferno: {
+				DisplayName: Inferno
+				Tooltip: ""
+			}
+
+			LoveBlade: {
+				DisplayName: Love Blade
+				Tooltip: ""
+			}
+
+			SoulEater: {
+				DisplayName: Soul Eater
+				Tooltip: ""
+			}
+
+			GiantSlayer: {
+				DisplayName: Giant Slayer
+				Tooltip: ""
+			}
+
+			SwiftBrand: {
+				DisplayName: Swift Brand
+				Tooltip: ""
+			}
+
+			SwordBreaker: {
+				DisplayName: Sword Breaker
+				Tooltip: ""
+			}
+
+			IceNeedle: {
+				DisplayName: Ice Needle
+				Tooltip: ""
+			}
+
+			UltraPro9000X: {
+				DisplayName: Ultra Pro9000 X
+				Tooltip: ""
+			}
+		}
+
+		Magic: {
+			SpellRegeneration: {
+				Tooltip: ""
+				DisplayName: Spell Regeneration
+			}
+
+			SpellProtect: {
+				Tooltip: ""
+				DisplayName: Spell Protect
+			}
+
+			ShootingStar: {
+				Tooltip: ""
+				DisplayName: Shooting Star
+			}
+
+			Seraphim: {
+				Tooltip: ""
+				DisplayName: Seraphim
+			}
+
+			Flameheart: {
+				Tooltip: ""
+				DisplayName: Flameheart
+			}
+
+			DarkTooth: {
+				Tooltip: ""
+				DisplayName: Dark Tooth
+			}
+
+			Airstrike_Remote: {
+				Tooltip: ""
+				DisplayName: Airstrike_ Remote
+			}
+		}
+
+		Ranged: {
+			CrimsonDragon: {
+				DisplayName: Crimson Dragon
+				Tooltip: ""
+			}
+		}
+	}
+
+	Accessories: {
+		TargetBadge: {
+			Tooltip: ""
+			DisplayName: Target Badge
+		}
+
+		SwordMedal: {
+			Tooltip: ""
+			DisplayName: Sword Medal
+		}
+
+		ShieldMedal: {
+			Tooltip: ""
+			DisplayName: Shield Medal
+		}
+
+		IronCross: {
+			Tooltip: ""
+			DisplayName: Iron Cross
+		}
+
+		GreenCross: {
+			Tooltip: ""
+			DisplayName: Green Cross
+		}
+
+		BalanceBadge: {
+			Tooltip: ""
+			DisplayName: Balance Badge
+		}
+
+		AngryFaic: {
+			Tooltip: ""
+			DisplayName: Angry Faic
+		}
+	}
 }

--- a/Localization/en-US_Mods.EBF.hjson
+++ b/Localization/en-US_Mods.EBF.hjson
@@ -108,94 +108,122 @@ Items: {
 			}
 
 			Avenger: {
-				Tooltip: ""
+				Tooltip:
+					'''
+					Grows stronger as health decreases.
+					For every scar, for every dishonor, the Avenger sharpens its edge. 
+					'''
 				DisplayName: Avenger
 			}
 
 			Anarchy: {
-				Tooltip: ""
+				Tooltip:
+					'''
+					Reduced defense while held.
+					Grows stronger at low health.
+					'''
 				DisplayName: Anarchy
 			}
 
 			BlackFang: {
+				Tooltip: "'This weapon is totally historically accurate, I'm sure of it. I saw it in an anime once!' - Matt"
 				DisplayName: Black Fang
-				Tooltip: ""
 			}
 
 			Blizzard: {
+				Tooltip: Shoots an additional bolt of frost at the cost of some accuracy.
 				DisplayName: Blizzard
-				Tooltip: ""
 			}
 
 			BloodBlade: {
+				Tooltip: Drains the health of hit foes.
 				DisplayName: Blood Blade
-				Tooltip: ""
 			}
 
 			DragonsFeather: {
-				DisplayName: Dragons Feather
 				Tooltip: ""
+				DisplayName: Dragons Feather
 			}
 
 			FusionBlade: {
+				Tooltip:
+					'''
+					Shoots a homing bullet bob.
+					Modeled after the weapons used by the MILITIA branch.
+					'''
 				DisplayName: Fusion Blade
-				Tooltip: ""
 			}
 
 			HeavensGate: {
+				Tooltip: A legendary sword belonging to a line of famed corsairs.
 				DisplayName: Heavens Gate
-				Tooltip: ""
 			}
 
 			Inferno: {
+				Tooltip:
+					'''
+					Burns foes.
+					Wreathed in scorching flames. 
+					'''
 				DisplayName: Inferno
-				Tooltip: ""
 			}
 
 			LoveBlade: {
-				DisplayName: Love Blade
 				Tooltip: ""
+				DisplayName: Love Blade
 			}
 
 			SoulEater: {
+				Tooltip:
+					'''
+					Deals massive damage but reduces your defense by 50% when held.
+					Honestly, it could have been worse. It could kill you instantly.
+					'''
 				DisplayName: Soul Eater
-				Tooltip: ""
 			}
 
 			GiantSlayer: {
-				DisplayName: Giant Slayer
 				Tooltip: ""
+				DisplayName: Giant Slayer
 			}
 
 			SwiftBrand: {
+				Tooltip: "'It's so easy to swing around!' - Matt"
 				DisplayName: Swift Brand
-				Tooltip: ""
 			}
 
 			SwordBreaker: {
+				Tooltip: Applies weak to hit foes.
 				DisplayName: Sword Breaker
-				Tooltip: ""
 			}
 
 			IceNeedle: {
-				DisplayName: Ice Needle
 				Tooltip: ""
+				DisplayName: Ice Needle
 			}
 
 			UltraPro9000X: {
-				DisplayName: Ultra Pro9000 X
-				Tooltip: ""
+				Tooltip: "'I can use this old hockey stick as a weapon. I think that should be enough equipment for now.' - Matt"
+				DisplayName: UltraPro9000X
 			}
 		}
 
 		Magic: {
 			SpellRegeneration: {
-				Tooltip: ""
+				Tooltip:
+					'''
+					Costs a lot of mana and has a big cooldown.
+					This spell vastly increases your regeneration.
+					'''
 				DisplayName: Spell Regeneration
 			}
 
 			SpellProtect: {
-				Tooltip: ""
+				Tooltip:
+					'''
+					Blocks 25% of the damage received.
+					This spell vastly protects you from enemy attacks.
+					'''
 				DisplayName: Spell Protect
 			}
 
@@ -205,67 +233,107 @@ Items: {
 			}
 
 			Seraphim: {
-				Tooltip: ""
+				Tooltip: A glorious staff used by gorgeous angels.
 				DisplayName: Seraphim
 			}
 
 			Flameheart: {
-				Tooltip: ""
+				Tooltip:
+					'''
+					Every third use summons a firestorm.
+					A common but powerful staff, used by mages to scorch foes.
+					'''
 				DisplayName: Flameheart
 			}
 
 			DarkTooth: {
-				Tooltip: ""
+				Tooltip:
+					'''
+					Creates a growing black hole that pulls everything and explodes upon being released.
+					An ancient black magic staff used for Dark elemental magic. 
+					'''
 				DisplayName: Dark Tooth
 			}
 
 			Airstrike_Remote: {
-				Tooltip: ""
+				Tooltip:
+					'''
+					Left click to drop a big bomb from the sky, right click to drop 3 weaker bombs at once.
+					Bombs away!!!!
+					'''
 				DisplayName: Airstrike_ Remote
 			}
 		}
 
 		Ranged: {
 			CrimsonDragon: {
-				DisplayName: Crimson Dragon
 				Tooltip: ""
+				DisplayName: Crimson Dragon
 			}
 		}
 	}
 
 	Accessories: {
 		TargetBadge: {
-			Tooltip: ""
+			Tooltip:
+				'''
+				Increases critical chance by 4%.
+				Increases enemy aggression.
+				Somehow putting a target on yourself makes you a better shot, who knew?
+				'''
 			DisplayName: Target Badge
 		}
 
 		SwordMedal: {
-			Tooltip: ""
+			Tooltip:
+				'''
+				Increases Ranged and Melee damage by 20%.
+				True might is the mark of discipline, honor and courage.
+				'''
 			DisplayName: Sword Medal
 		}
 
 		ShieldMedal: {
-			Tooltip: ""
+			Tooltip: Aid others where you can. Let all be helped and loved throughout the realm.
 			DisplayName: Shield Medal
 		}
 
 		IronCross: {
-			Tooltip: ""
+			Tooltip:
+				'''
+				Boosts ranged damage by 10%.
+				A war medal which offers protection. Lance's favourite flair.
+				'''
 			DisplayName: Iron Cross
 		}
 
 		GreenCross: {
-			Tooltip: ""
+			Tooltip:
+				'''
+				Regenerates 5% of your maximum health every 10 seconds.
+				A Geneva-Convention-friendly pin which boasts regenerative properties.
+				'''
 			DisplayName: Green Cross
 		}
 
 		BalanceBadge: {
-			Tooltip: ""
+			Tooltip:
+				'''
+				Increases maximum health and mana by 10.
+				Increases movement, attack speed, damage and crit chance by 5%.
+				Increases max minion slots by 1.
+				Represents pure equilibrium and bestows a wealth of boosts.
+				'''
 			DisplayName: Balance Badge
 		}
 
 		AngryFaic: {
-			Tooltip: ""
+			Tooltip:
+				'''
+				Increases critical chance by 8%.
+				Increases enemy aggression.
+				Wearing this makes you so angry, you want something to be BLAMMED!
+				'''
 			DisplayName: Angry Faic
 		}
 	}


### PR DESCRIPTION
So the old way item names and tooltips were written is apparently wrong.
The code in SetStaticDefaults() does NOT change the display name and tooltips, because the game takes it from the localization files. These files also do not update from SetStaticDefaults().

So what I've done is I've deleted all the SetStaticDefaults() methods from every item that doesn't do anything other than attempt to set display name and tooltip. In return, I've added the tooltips manually to the localization file.

I have also made the items implement ILocalizedModType, which allows the item to generate or place the display name and tooltip into categories for easier maintenance. You'll notice in the localization file that there's now a category for melee, magic, ranged and accessory items.

This way of handling tooltips and display names matches with how the Calamity mod does it.