### PR TITLE
Charged arrows rework

### DIFF
--- a/Abstract_Classes/EBFChargeableArrow.cs
+++ b/Abstract_Classes/EBFChargeableArrow.cs
@@ -11,23 +11,25 @@ namespace EBF.Abstract_Classes
 {
     public abstract class EBFChargeableArrow : ModProjectile
     {
-        private bool isReleased = false;
-        private int baseAiStyle;
-        private float drawTime = 0;//The current charge value
-        private bool giveTileCollision = false;//stores arrow tilecollision bool for later so it doesn't hit things while the player is drawing the arrow.
-        private float baseVelocity; //Set this SetDefaults in each bow
+        private bool isReleased = false; //Flag to prevent flying arrows from warping back to the bow. It's likely caused by some reference type shenanigans.
+        private bool giveTileCollision = false; //Stores the projectile's tilecollision for later, to be set when the held arrow is released.
+        private int baseAiStyle; //Stores the projectile's AI for later, to be set when the held arrow is released.
+        private float baseVelocity; //Stores the projectile's velocity for later, to be set when the held arrow is released.
+        private float drawTime = 0;//The current charge value.
 
         /// <summary>
         /// The maximum amount of charge an arrow can have, at which point draw time will stop increasing. Draw time starts at 0 and ticks up by 1 every update while an arrow exists.
         /// <br>If you wish to check if the arrow is fully charged, use the FullyCharged property instead.</br>
+        /// <para>Defaults to 80.</para>
         /// </summary>
-        protected int MaximumDrawTime { get; set; }//Set this SetDefaults in each bow
+        protected int MaximumDrawTime { get; set; } = 80;
 
         /// <summary>
         /// The minimum time it takes before an arrow can be released. Draw time starts at 0 and ticks up by 1 every update while an arrow exists.
         /// <br>If the player releases their click earlier than this given time, the bow will keep charging until it meets this threshold, at which it will then shoot.</br>
+        /// <para>Defaults to 30.</para>
         /// </summary>
-        protected int MinimumDrawTime { get; set; }//Set this SetDefaults in each bow
+        protected int MinimumDrawTime { get; set; } = 30;
 
         /// <summary>
         /// True when the arrow is fully charged.

--- a/Items/Ranged/Bows/EagleEye.cs
+++ b/Items/Ranged/Bows/EagleEye.cs
@@ -34,6 +34,7 @@ namespace EBF.Items.Ranged.Bows
             Item.shoot = ProjectileID.WoodenArrowFriendly;
             Item.shootSpeed = 8f;
             Item.channel = true;
+            Item.noMelee = true;
         }
         public override bool CanUseItem(Player player)
         {
@@ -50,11 +51,11 @@ namespace EBF.Items.Ranged.Bows
 
     public class EagleEye_Arrow : EBFChargeableArrow
     {
-        public override string Texture => $"Terraria/Images/Projectile_{ProjectileID.UnholyArrow}";
+        public override string Texture => $"Terraria/Images/Projectile_{ProjectileID.WoodenArrowFriendly}";
         public override void SetDefaults()
         {
-            Projectile.width = 70;
-            Projectile.height = 20;
+            Projectile.width = 14;
+            Projectile.height = 32;
 
             Projectile.extraUpdates = 1; //Don't forget that extra updates also increases perceived velocity
             Projectile.penetrate = -1;
@@ -73,18 +74,6 @@ namespace EBF.Items.Ranged.Bows
 
             Projectile.localNPCHitCooldown = -1;
             Projectile.usesLocalNPCImmunity = true;
-        }
-        public override void OnProjectileRelease()
-        {
-            Projectile.NewProjectile(Projectile.GetSource_FromThis(), Projectile.position, Projectile.velocity, ProjectileID.UnholyArrow, Projectile.damage, Projectile.knockBack, Projectile.owner);
-        }
-        public override void OnKill(int timeLeft)
-        {
-            for (int i = 0; i < 30; i++)
-            {
-                Dust dust = Dust.NewDustDirect(Projectile.position, Projectile.width, Projectile.height, DustID.AncientLight, SpeedX: 0, SpeedY: 0);
-                dust.noGravity = true;
-            }
         }
     }
 }

--- a/Items/Ranged/Bows/EagleEye.cs
+++ b/Items/Ranged/Bows/EagleEye.cs
@@ -50,7 +50,7 @@ namespace EBF.Items.Ranged.Bows
 
     public class EagleEye_Arrow : EBFChargeableArrow
     {
-        public override string Texture => $"Terraria/Images/Projectile_{ProjectileID.WoodenArrowFriendly}";
+        public override string Texture => $"Terraria/Images/Projectile_{ProjectileID.UnholyArrow}";
         public override void SetDefaults()
         {
             Projectile.width = 70;
@@ -59,9 +59,10 @@ namespace EBF.Items.Ranged.Bows
             Projectile.extraUpdates = 1; //Don't forget that extra updates also increases perceived velocity
             Projectile.penetrate = -1;
             Projectile.friendly = false;
-            Projectile.tileCollide = false;
-            Projectile.hide = true;
+            Projectile.tileCollide = true;
+            Projectile.hide = false;
             Projectile.DamageType = DamageClass.Ranged;
+            Projectile.aiStyle = ProjAIStyleID.Arrow;
             Projectile.ignoreWater = true;
 
             MaximumDrawTime = 100;
@@ -72,6 +73,18 @@ namespace EBF.Items.Ranged.Bows
 
             Projectile.localNPCHitCooldown = -1;
             Projectile.usesLocalNPCImmunity = true;
+        }
+        public override void OnProjectileRelease()
+        {
+            Projectile.NewProjectile(Projectile.GetSource_FromThis(), Projectile.position, Projectile.velocity, ProjectileID.UnholyArrow, Projectile.damage, Projectile.knockBack, Projectile.owner);
+        }
+        public override void OnKill(int timeLeft)
+        {
+            for (int i = 0; i < 30; i++)
+            {
+                Dust dust = Dust.NewDustDirect(Projectile.position, Projectile.width, Projectile.height, DustID.AncientLight, SpeedX: 0, SpeedY: 0);
+                dust.noGravity = true;
+            }
         }
     }
 }


### PR DESCRIPTION
Instead of killing the held projectile and spawning a new. The base class AI now simply gives the original projectile stats back to the held arrow on release, meaning the actual projectile that is fired is the same as the one spawned by the subclass. This gives the following benefits:
1. The held and ultimately fired arrow now has the same properties as the main projectile.
2. OnKill hook is now called when the fired arrow dies, and not when the bow releases the arrow.
3. OnHitNPC hook is now possible due to it not being restricted to just the bow's position.
4. All other hooks related to the projectile's current position now works.

Two bugs were also fixed. The bow itself used to have an active hitbox, and the arrow hitbox mismatched its sprite.