### PR TITLE
Neon Valkyrie Relic Implementation

### DIFF
--- a/Localization/en-US_Mods.EBF.hjson
+++ b/Localization/en-US_Mods.EBF.hjson
@@ -409,7 +409,7 @@ Items: {
 	}
 
 	NeonValkRelic: {
-		DisplayName: Neon Valk Relic
+		DisplayName: Neon Valkyrie Relic
 		Tooltip: ""
 	}
 

--- a/NPCs/Bosses/NeonValkyrie/NeonValkyrie.cs
+++ b/NPCs/Bosses/NeonValkyrie/NeonValkyrie.cs
@@ -249,7 +249,7 @@ namespace EBF.NPCs.Bosses.NeonValkyrie
             npcLoot.Add(ItemDropRule.BossBag(ModContent.ItemType<NeonValkBossBag>()));
 
             // Relic
-            //npcLoot.Add(ItemDropRule.MasterModeCommonDrop(ModContent.ItemType<Items.Placeable.Furniture.NeonValkRelic>()));
+            npcLoot.Add(ItemDropRule.MasterModeCommonDrop(ModContent.ItemType<Items.Placeables.Furniture.BossRelics.NeonValkRelic>()));
 
             // Pet
             //npcLoot.Add(ItemDropRule.MasterModeDropOnAllPlayers(ModContent.ItemType<NeonValkPetItem>(), 4));


### PR DESCRIPTION
Made the Neon Valkyrie Relic drop from the Neon Valkyrie, as well as renamed it from the shortened "Neon Valk Relic" to the full "Neon Valkyrie Relic".